### PR TITLE
SYS-3801 Adds state migration for summary pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-lower-rpc"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "avn-service",
  "futures",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "avn-node-parachain"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "avn-lower-rpc",
  "avn-parachain-runtime",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "avn-parachain-runtime",
@@ -6510,7 +6510,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6557,7 +6557,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6581,7 +6581,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6863,7 +6863,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -6889,7 +6889,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7189,7 +7189,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7451,7 +7451,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7518,7 +7518,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7627,7 +7627,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11939,7 +11939,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7459,6 +7459,7 @@ dependencies = [
  "frame-system",
  "hex",
  "hex-literal",
+ "log",
  "node-primitives",
  "pallet-avn",
  "pallet-eth-bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/pallets/parachain-staking/src/migration.rs
+++ b/pallets/parachain-staking/src/migration.rs
@@ -134,7 +134,12 @@ impl<T: Config> OnRuntimeUpgrade for EnableEthBridgeWireUp<T> {
 
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
-        assert_eq!(true, storage_with_voting::VotingPeriod::<T>::exists());
+        let current = Pallet::<T>::current_storage_version();
+        let onchain = Pallet::<T>::on_chain_storage_version();
+
+        if onchain == 2 && current == 3 {
+            assert_eq!(true, storage_with_voting::VotingPeriod::<T>::exists());
+        }
 
         Ok(vec![])
     }

--- a/pallets/summary/Cargo.toml
+++ b/pallets/summary/Cargo.toml
@@ -16,7 +16,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = { version = "0.3.4", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-
+log = { version = "0.4.17", default-features = false }
 sp-avn-common = { default-features = false, path = "../../primitives/avn-common" }
 pallet-avn = { path = "../avn", default-features = false }
 

--- a/pallets/summary/src/migration.rs
+++ b/pallets/summary/src/migration.rs
@@ -1,0 +1,102 @@
+// AvN is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    Clone, Config, Decode, Encode, EthereumTransactionId, Pallet, RootData, Roots, TypeInfo, H256,
+    STORAGE_VERSION,
+};
+
+use frame_support::{
+    dispatch::GetStorageVersion,
+    pallet_prelude::*,
+    traits::{Get, OnRuntimeUpgrade},
+    weights::Weight,
+};
+use sp_std::prelude::*;
+
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct OldRootData<AccountId> {
+    pub root_hash: H256,
+    pub added_by: Option<AccountId>,
+    pub is_validated: bool,
+    pub is_finalised: bool,
+    pub tx_id: Option<u64>,
+}
+
+pub fn migrate_roots<T: Config>() -> Weight {
+    let mut consumed_weight: Weight = Weight::from_ref_time(0);
+    let mut add_weight = |reads, writes, weight: Weight| {
+        consumed_weight += T::DbWeight::get().reads_writes(reads, writes);
+        consumed_weight += weight;
+    };
+
+    let mut counter = 0;
+
+    Roots::<T>::translate::<OldRootData<T::AccountId>, _>(
+        |_range, _ingress, old_root_data: OldRootData<T::AccountId>| {
+            add_weight(1, 1, Weight::from_ref_time(0));
+
+            let new_transaction_id: Option<EthereumTransactionId> =
+                old_root_data.tx_id.map(|value| value.try_into().ok()).flatten();
+
+            let new_root_data: RootData<T::AccountId> = RootData::new(
+                old_root_data.root_hash,
+                old_root_data.added_by.expect("Existing data will always have an added by"),
+                new_transaction_id,
+            );
+
+            counter += 1;
+            Some(new_root_data)
+        },
+    );
+
+    //Write: [STORAGE_VERSION]
+    add_weight(0, 1, Weight::from_ref_time(0));
+    STORAGE_VERSION.put::<Pallet<T>>();
+
+    log::info!(
+        "✅ Summary root data migration completed successfully. {:?} entries migrated",
+        counter
+    );
+
+    // add a bit extra as safety margin for computation
+    return consumed_weight + Weight::from_ref_time(25_000_000_000)
+}
+
+/// Migration to enable staking pallet
+pub struct MigrateSummaryRootData<T>(PhantomData<T>);
+impl<T: Config> OnRuntimeUpgrade for MigrateSummaryRootData<T> {
+    fn on_runtime_upgrade() -> Weight {
+        let current = Pallet::<T>::current_storage_version();
+        let onchain = Pallet::<T>::on_chain_storage_version();
+
+        if onchain < 1 {
+            log::info!(
+                "🚧 Running summary migration. Current storage version: {:?}, on-chain version: {:?}",
+                current,
+                onchain
+            );
+            return migrate_roots::<T>()
+        }
+
+        Weight::zero()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+        Ok(vec![])
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(_input: Vec<u8>) -> Result<(), &'static str> {
+        let onchain_version = Pallet::<T>::on_chain_storage_version();
+        frame_support::ensure!(onchain_version == 1, "must_upgrade");
+
+        Ok(())
+    }
+}

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -296,7 +296,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 56,
+    spec_version: 57,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -268,7 +268,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-test-parachain"),
     impl_name: create_runtime_str!("avn-test-parachain"),
     authoring_version: 1,
-    spec_version: 56,
+    spec_version: 57,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Proposed changes

This PR adds a state migration to the summary pallet to avoid corrupting the roots data storage

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [x] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [x] Documentation updated
- [x] Business logic tested successfully
- [x] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
