### PR TITLE
SYS-3867 SYS-3865 Update benchmark for Summary and EthereumEvents

### DIFF
--- a/pallets/ethereum-events/src/benchmarking.rs
+++ b/pallets/ethereum-events/src/benchmarking.rs
@@ -17,6 +17,10 @@ use sp_runtime::WeakBoundedVec;
 pub type AVN<T> = avn::Pallet<T>;
 
 const MAX_NUMBER_OF_VALIDATORS_ACCOUNTS: u32 = 10;
+const MAX_NUMBER_OF_UNCHECKED_EVENTS_BENCH: u32 = MAX_NUMBER_OF_UNCHECKED_EVENTS - 1;
+const MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES_BENCH: u32 =
+    MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES - 1;
+const MAX_CHALLENGES_BENCH: u32 = MAX_CHALLENGES - 1;
 
 fn setup_unchecked_events<T: Config>(event_type: &ValidEvents, number_of_unchecked_events: u32) {
     let mut unchecked_added_validator_events: Vec<(EthEventId, IngressCounter, T::BlockNumber)> =
@@ -146,8 +150,8 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 
 benchmarks! {
     add_validator_log {
-        let u = MAX_NUMBER_OF_UNCHECKED_EVENTS-2;
-        let e = MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES-3;
+        let u in 1 .. MAX_NUMBER_OF_UNCHECKED_EVENTS_BENCH;
+        let e in 1 .. MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES_BENCH;
 
         let event_type = ValidEvents::AddedValidator;
         setup_unchecked_events::<T>(&event_type, u);
@@ -173,8 +177,8 @@ benchmarks! {
     }
 
     add_lift_log {
-        let u in 1 .. MAX_NUMBER_OF_UNCHECKED_EVENTS-2;
-        let e in 1 .. MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES-3;
+        let u in 1 .. MAX_NUMBER_OF_UNCHECKED_EVENTS_BENCH;
+        let e in 1 .. MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES_BENCH;
 
         let event_type = ValidEvents::Lifted;
         setup_unchecked_events::<T>(&event_type, u);
@@ -199,8 +203,8 @@ benchmarks! {
     }
 
     add_ethereum_log {
-        let u = MAX_NUMBER_OF_UNCHECKED_EVENTS-2;
-        let e = MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES-3;
+        let u in 1 .. MAX_NUMBER_OF_UNCHECKED_EVENTS_BENCH;
+        let e in 1 .. MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES_BENCH;
 
         let event_type = ValidEvents::NftMint;
         setup_unchecked_events::<T>(&event_type, u);
@@ -224,8 +228,8 @@ benchmarks! {
     }
 
     signed_add_ethereum_log {
-        let u = MAX_NUMBER_OF_UNCHECKED_EVENTS-2;
-        let e = MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES-3;
+        let u in 1 .. MAX_NUMBER_OF_UNCHECKED_EVENTS_BENCH;
+        let e in 1 .. MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES_BENCH;
 
         let event_type = ValidEvents::NftMint;
         setup_unchecked_events::<T>(&event_type, u);
@@ -267,8 +271,8 @@ benchmarks! {
     }
 
     submit_checkevent_result {
-        let v = MAX_NUMBER_OF_VALIDATORS_ACCOUNTS-2;
-        let u = MAX_NUMBER_OF_UNCHECKED_EVENTS-3;
+        let v in 1 .. MAX_NUMBER_OF_VALIDATORS_ACCOUNTS;
+        let u in 1 .. MAX_NUMBER_OF_UNCHECKED_EVENTS_BENCH;
 
         let event_type = ValidEvents::Lifted;
         setup_unchecked_events::<T>(&event_type, u);
@@ -298,8 +302,8 @@ benchmarks! {
     }
 
     process_event_with_successful_challenge {
-        let v = MAX_NUMBER_OF_VALIDATORS_ACCOUNTS-2;
-        let e = MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES-3;
+        let v in 1 .. MAX_NUMBER_OF_VALIDATORS_ACCOUNTS;
+        let e in 1 .. MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES_BENCH;
 
         let validators = setup_validators::<T>(v);
         let (result, ingress_counter, signature, validator) = setup_extrinsics_inputs::<T>(validators.clone());
@@ -320,8 +324,8 @@ benchmarks! {
     }
 
     process_event_without_successful_challenge {
-        let v = MAX_NUMBER_OF_VALIDATORS_ACCOUNTS-2;
-        let e = MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES-3;
+        let v in 1 .. MAX_NUMBER_OF_VALIDATORS_ACCOUNTS;
+        let e in 1 .. MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES_BENCH;
 
         let validators = setup_validators::<T>(v);
         let (mut result, ingress_counter, signature, validator) = setup_extrinsics_inputs::<T>(validators.clone());
@@ -339,9 +343,9 @@ benchmarks! {
     }
 
     challenge_event {
-        let v = MAX_NUMBER_OF_VALIDATORS_ACCOUNTS-2;
-        let e = MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES-3;
-        let c = MAX_CHALLENGES-2;
+        let v in 3 .. MAX_NUMBER_OF_VALIDATORS_ACCOUNTS;
+        let e in 1 .. MAX_NUMBER_OF_EVENTS_PENDING_CHALLENGES_BENCH;
+        let c in 1 .. MAX_CHALLENGES_BENCH;
 
         let mut validators = setup_validators::<T>(v);
         let (result, ingress_counter, signature, validator) = setup_extrinsics_inputs::<T>(validators.clone());

--- a/pallets/summary/src/benchmarking.rs
+++ b/pallets/summary/src/benchmarking.rs
@@ -227,13 +227,13 @@ benchmarks! {
     }
 
     record_summary_calculation {
-        let number_of_validators = MAX_VALIDATOR_ACCOUNT_IDS;
-        let mut validators = setup_validators::<T>(number_of_validators);
-        let max_root = MAX_NUMBER_OF_ROOT_DATA_PER_RANGE;
+        let v in 3 .. MAX_VALIDATOR_ACCOUNT_IDS;
+        let r in 1 .. MAX_NUMBER_OF_ROOT_DATA_PER_RANGE;
 
+        let validators = setup_validators::<T>(v);
         let validator = validators[validators.len() - (1 as usize)].clone();
         let (new_block_number, root_hash, ingress_counter, signature) = setup_record_summary_calculation::<T>();
-        setup_roots::<T>(max_root, validator.account_id.clone(), ingress_counter);
+        setup_roots::<T>(r, validator.account_id.clone(), ingress_counter);
         let next_block_to_process = NextBlockToProcess::<T>::get();
     }: _(RawOrigin::None, new_block_number, root_hash, ingress_counter, validator.clone(), signature)
     verify {
@@ -252,9 +252,10 @@ benchmarks! {
     }
 
     approve_root_with_end_voting {
-        let number_of_offenders = MAX_OFFENDERS;
-        let number_of_validators = MAX_VALIDATOR_ACCOUNT_IDS;
-        let mut validators = setup_validators::<T>(number_of_validators);
+        let v in 3 .. MAX_VALIDATOR_ACCOUNT_IDS;
+        let o in 1 .. MAX_OFFENDERS;
+
+        let mut validators = setup_validators::<T>(v);
         let (sender, root_id,  signature, quorum) = setup_publish_root_voting::<T>(validators.clone());
         validators.remove(validators.len() - (1 as usize)); // Avoid setting up sender to approve vote automatically
 
@@ -266,7 +267,7 @@ benchmarks! {
 
         let mut reject_voters = validators.clone();
         reject_voters.reverse();
-        setup_reject_votes::<T>(&reject_voters, number_of_offenders, &root_id);
+        setup_reject_votes::<T>(&reject_voters, o, &root_id);
 
         CurrentSlot::<T>::put::<T::BlockNumber>(3u32.into());
 
@@ -319,8 +320,8 @@ benchmarks! {
     }
 
     approve_root_without_end_voting {
-        let number_of_validators = MAX_VALIDATOR_ACCOUNT_IDS;
-        let mut validators = setup_validators::<T>(number_of_validators);
+        let v in 4 .. MAX_VALIDATOR_ACCOUNT_IDS;
+        let validators = setup_validators::<T>(v);
         let (sender, root_id,  signature, quorum) = setup_publish_root_voting::<T>(validators.clone());
         setup_roots::<T>(1, sender.account_id.clone(), root_id.ingress_counter - 1);
 
@@ -343,9 +344,10 @@ benchmarks! {
     }
 
     reject_root_with_end_voting {
-        let number_of_offenders = MAX_OFFENDERS;
-        let number_of_validators = MAX_VALIDATOR_ACCOUNT_IDS;
-        let mut validators = setup_validators::<T>(number_of_validators);
+        let v in 7 .. MAX_VALIDATOR_ACCOUNT_IDS;
+        let o in 1 .. MAX_OFFENDERS;
+
+        let mut validators = setup_validators::<T>(v);
         let (sender, root_id, signature, quorum) = setup_publish_root_voting::<T>(validators.clone());
         validators.remove(validators.len() - (1 as usize)); // Avoid setting up sender to reject vote automatically
 
@@ -357,7 +359,7 @@ benchmarks! {
 
         let mut approve_voters = validators.clone();
         approve_voters.reverse();
-        setup_approval_votes::<T>(&approve_voters, number_of_offenders, &root_id);
+        setup_approval_votes::<T>(&approve_voters, o, &root_id);
     }: reject_root(RawOrigin::None, root_id.clone(), sender.clone(), signature)
     verify {
         assert_eq!(false, NextBlockToProcess::<T>::get() == root_id.range.to_block + 1u32.into());
@@ -395,8 +397,8 @@ benchmarks! {
     }
 
     reject_root_without_end_voting {
-        let number_of_validators = MAX_VALIDATOR_ACCOUNT_IDS;
-        let mut validators = setup_validators::<T>(number_of_validators);
+        let v in 4 .. MAX_VALIDATOR_ACCOUNT_IDS;
+        let mut validators = setup_validators::<T>(v);
         let (sender, root_id,  signature, quorum) = setup_publish_root_voting::<T>(validators.clone());
         validators.remove(validators.len() - (1 as usize)); // Avoid setting up sender to reject vote automatically
 


### PR DESCRIPTION
## Proposed changes

This PR updates the benchmark for the Summary and Ethereum events pallet by taking into account MAX values of storage items.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
