### PR TITLE
SYS-3635: extends the voting mechanism

### DIFF
--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -1,6 +1,10 @@
-use sp_avn_common::event_types::{
-    AddedValidatorData, AvtGrowthLiftedData, Error, EthEvent, EthEventId, EventData, LiftedData,
-    NftCancelListingData, NftEndBatchListingData, NftMintData, NftTransferToData, ValidEvents,
+use sp_avn_common::{
+    event_discovery::DiscoveredEvent,
+    event_types::{
+        AddedValidatorData, AvtGrowthLiftedData, Error, EthEvent, EthEventId, EventData,
+        LiftedData, NftCancelListingData, NftEndBatchListingData, NftMintData, NftTransferToData,
+        ValidEvents,
+    },
 };
 use web3::{
     types::{FilterBuilder, Log, H160, H256, U64},
@@ -12,7 +16,7 @@ pub enum AppError {
     ErrorGettingEventLogs,
     MissingTransactionHash,
     MissingBlockNumber,
-    ParsingError(Error)
+    ParsingError(Error),
 }
 
 pub async fn identify_events(
@@ -99,40 +103,26 @@ fn parse_event_data(
     topics: Vec<Vec<u8>>,
 ) -> Result<EventData, AppError> {
     match event_type {
-        ValidEvents::AddedValidator => {
-            AddedValidatorData::parse_bytes(Some(data), topics)
-                .map_err(|err| AppError::ParsingError(err.into()))
-                .map(EventData::LogAddedValidator)
-        }
-        ValidEvents::Lifted => {
-            LiftedData::parse_bytes(Some(data), topics)
-                .map_err(|err| AppError::ParsingError(err.into()))
-                .map(EventData::LogLifted)
-        }
-        ValidEvents::NftMint => {
-            NftMintData::parse_bytes(Some(data), topics)
-                .map_err(|err| AppError::ParsingError(err.into()))
-                .map(EventData::LogNftMinted)
-        }
-        ValidEvents::NftTransferTo => {
-            NftTransferToData::parse_bytes(Some(data), topics)
-                .map_err(|err| AppError::ParsingError(err))
-                .map(EventData::LogNftTransferTo)
-        }
-        ValidEvents::NftCancelListing => {
-            NftCancelListingData::parse_bytes(Some(data), topics)
-                .map_err(|err| AppError::ParsingError(err.into()))
-                .map(EventData::LogNftCancelListing)
-        }
-        ValidEvents::NftEndBatchListing => {
-            NftEndBatchListingData::parse_bytes(Some(data), topics)
-                .map_err(|err| AppError::ParsingError(err.into()))
-                .map(EventData::LogNftEndBatchListing)
-        }
-        ValidEvents::AvtGrowthLifted => {
-            AvtGrowthLiftedData::parse_bytes(Some(data), topics)
-                .map_err(|err| AppError::ParsingError(err.into()))
-                .map(EventData::LogAvtGrowthLifted)
-        }
+        ValidEvents::AddedValidator => AddedValidatorData::parse_bytes(Some(data), topics)
+            .map_err(|err| AppError::ParsingError(err.into()))
+            .map(EventData::LogAddedValidator),
+        ValidEvents::Lifted => LiftedData::parse_bytes(Some(data), topics)
+            .map_err(|err| AppError::ParsingError(err.into()))
+            .map(EventData::LogLifted),
+        ValidEvents::NftMint => NftMintData::parse_bytes(Some(data), topics)
+            .map_err(|err| AppError::ParsingError(err.into()))
+            .map(EventData::LogNftMinted),
+        ValidEvents::NftTransferTo => NftTransferToData::parse_bytes(Some(data), topics)
+            .map_err(|err| AppError::ParsingError(err))
+            .map(EventData::LogNftTransferTo),
+        ValidEvents::NftCancelListing => NftCancelListingData::parse_bytes(Some(data), topics)
+            .map_err(|err| AppError::ParsingError(err.into()))
+            .map(EventData::LogNftCancelListing),
+        ValidEvents::NftEndBatchListing => NftEndBatchListingData::parse_bytes(Some(data), topics)
+            .map_err(|err| AppError::ParsingError(err.into()))
+            .map(EventData::LogNftEndBatchListing),
+        ValidEvents::AvtGrowthLifted => AvtGrowthLiftedData::parse_bytes(Some(data), topics)
+            .map_err(|err| AppError::ParsingError(err.into()))
+            .map(EventData::LogAvtGrowthLifted),
     }
 }

--- a/node/avn-service/src/lib.rs
+++ b/node/avn-service/src/lib.rs
@@ -20,8 +20,8 @@ use secp256k1::{Secp256k1, SecretKey};
 use tide::{http::StatusCode, Error as TideError};
 pub use web3Secp256k1::SecretKey as web3SecretKey;
 
-pub mod extrinsic_utils;
 pub mod ethereum_events_handler;
+pub mod extrinsic_utils;
 pub mod keystore_utils;
 pub mod merkle_tree_utils;
 pub mod summary_utils;

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -58,7 +58,9 @@ use alloc::{
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::convert::TryInto;
-use frame_support::{dispatch::DispatchResultWithPostInfo, log, traits::IsSubType, BoundedVec};
+use frame_support::{
+    dispatch::DispatchResultWithPostInfo, log, traits::IsSubType, BoundedBTreeSet, BoundedVec,
+};
 use frame_system::{
     ensure_none, ensure_root,
     offchain::{SendTransactionTypes, SubmitTransaction},
@@ -72,7 +74,7 @@ use pallet_session::historical::IdentificationTuple;
 use sp_staking::offence::ReportOffence;
 
 use sp_application_crypto::RuntimeAppPublic;
-use sp_avn_common::event_types::Validator;
+use sp_avn_common::{event_discovery::*, event_types::Validator};
 use sp_core::{ecdsa, ConstU32, H256};
 use sp_io::hashing::keccak_256;
 use sp_runtime::{scale_info::TypeInfo, traits::Dispatchable};
@@ -130,7 +132,11 @@ pub mod pallet {
     use crate::offence::CorroborationOffenceType;
 
     use super::*;
-    use frame_support::{pallet_prelude::*, traits::UnixTime, Blake2_128Concat};
+    use frame_support::{
+        pallet_prelude::{ValueQuery, *},
+        traits::UnixTime,
+        Blake2_128Concat,
+    };
 
     #[pallet::config]
     pub trait Config:
@@ -220,6 +226,21 @@ pub mod pallet {
     #[pallet::storage]
     pub type ActiveRequest<T: Config> = StorageValue<_, ActiveRequestData<T>, OptionQuery>;
 
+    #[pallet::storage]
+    #[pallet::getter(fn active_ethereum_range)]
+    pub type ActiveEthereumRange<T: Config> = StorageValue<_, EthBlockRange, OptionQuery>;
+
+    #[pallet::storage]
+    pub type DiscoveredEventsShard<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        EthBlockRange,
+        Blake2_128Concat,
+        DiscoveredEthEventsFraction,
+        BoundedBTreeSet<T::AccountId, VotesLimit>,
+        ValueQuery,
+    >;
+
     #[pallet::genesis_config]
     pub struct GenesisConfig<T: Config> {
         pub _phantom: sp_std::marker::PhantomData<T>,
@@ -279,6 +300,9 @@ pub mod pallet {
         LowerParamsError,
         CallerIdLengthExceeded,
         NoActiveRequest,
+        EventVotesFull,
+        EventVoteExists,
+        EventScanningDisabled,
     }
 
     #[pallet::call]
@@ -477,6 +501,37 @@ pub mod pallet {
             Self::deposit_event(Event::<T>::ActiveRequestRemoved { request_id });
             Ok(().into())
         }
+
+        #[pallet::call_index(6)]
+        #[pallet::weight(<T as Config>::WeightInfo::add_eth_tx_hash())]
+        pub fn submit_discovered_events(
+            origin: OriginFor<T>,
+            author: Author<T>,
+            range: EthBlockRange,
+            events_fraction: DiscoveredEthEventsFraction,
+            _signature: <T::AuthorityId as RuntimeAppPublic>::Signature,
+        ) -> DispatchResultWithPostInfo {
+            ensure_none(origin)?;
+
+            // Validate that the range is the current one.
+            let active_range =
+                Self::active_ethereum_range().ok_or(Error::<T>::EventScanningDisabled)?;
+            ensure!(range == active_range, Error::<T>::EventScanningDisabled);
+
+            // Check if already vote has been casted
+            let votes = DiscoveredEventsShard::<T>::get(&range, &events_fraction);
+            ensure!(votes.contains(&author.account_id) == false, Error::<T>::EventVoteExists);
+            ensure!(votes.len() as u32 >= AVN::<T>::quorum(), Error::<T>::EventVotesFull);
+
+            DiscoveredEventsShard::<T>::try_mutate(&range, &events_fraction, |votes| {
+                votes.try_insert(author.account_id)
+            })
+            .map_err(|_| Error::<T>::EventVotesFull)?;
+
+            // TODO process if ready
+
+            Ok(().into())
+        }
     }
 
     #[pallet::hooks]
@@ -599,6 +654,7 @@ pub mod pallet {
     #[pallet::validate_unsigned]
     impl<T: Config> ValidateUnsigned for Pallet<T> {
         type Call = Call<T>;
+        // TODO extend for submit_discovered_events
         // Confirm that the call comes from an author before it can enter the pool:
         fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
             match call {

--- a/primitives/avn-common/src/event_discovery.rs
+++ b/primitives/avn-common/src/event_discovery.rs
@@ -1,0 +1,118 @@
+use crate::*;
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use event_types::EthEvent;
+use sp_core::{bounded::BoundedBTreeSet, ConstU32};
+use sp_io::hashing::blake2_256;
+
+pub type VotesLimit = ConstU32<100>;
+pub type EventsBatchLimit = ConstU32<32>;
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]
+pub struct EthBlockRange {
+    pub start_block: u32,
+    pub length: u32,
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]
+pub struct DiscoveredEvent {
+    pub event: EthEvent,
+    pub block: u64,
+}
+
+impl PartialOrd for DiscoveredEvent {
+    fn partial_cmp(&self, other: &Self) -> Option<scale_info::prelude::cmp::Ordering> {
+        // TODO ensure that the comparison is lowercase.
+        let ord_sig = self.event.event_id.signature.partial_cmp(&other.event.event_id.signature);
+
+        if let Some(core::cmp::Ordering::Equal) = ord_sig {
+            return ord_sig
+        }
+
+        match self.block.partial_cmp(&other.block) {
+            Some(core::cmp::Ordering::Equal) => {},
+            ord => return ord,
+        }
+        ord_sig
+    }
+}
+
+impl Ord for DiscoveredEvent {
+    fn cmp(&self, other: &Self) -> scale_info::prelude::cmp::Ordering {
+        // TODO ensure that the comparison is lowercase.
+        let ord_sig = self.event.event_id.signature.cmp(&other.event.event_id.signature);
+
+        if let core::cmp::Ordering::Equal = ord_sig {
+            return ord_sig
+        }
+
+        match self.block.cmp(&other.block) {
+            core::cmp::Ordering::Equal => {},
+            ord => return ord,
+        }
+        ord_sig
+    }
+}
+
+type EthEventsPartition = BoundedBTreeSet<DiscoveredEvent, EventsBatchLimit>;
+#[derive(PartialEq, Eq, Clone, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
+pub struct DiscoveredEthEventsFraction {
+    data: EthEventsPartition,
+    fraction: u16,
+    fraction_count: u16,
+    id: H256,
+}
+
+impl DiscoveredEthEventsFraction {
+    pub fn events(&self) -> &EthEventsPartition {
+        &self.data
+    }
+
+    pub fn fraction(&self) -> u16 {
+        self.fraction
+    }
+
+    pub fn fraction_count(&self) -> u16 {
+        self.fraction
+    }
+
+    pub fn id(&self) -> &H256 {
+        &self.id
+    }
+
+    fn new(data: EthEventsPartition, fraction: u16, fraction_count: u16, id: &H256) -> Self {
+        DiscoveredEthEventsFraction { data, fraction, fraction_count, id: id.clone() }
+    }
+}
+
+pub mod events_helpers {
+    use super::*;
+    pub extern crate alloc;
+    use alloc::collections::BTreeSet;
+
+    pub fn discovered_eth_events_partition_factory(
+        events: Vec<DiscoveredEvent>,
+    ) -> Vec<DiscoveredEthEventsFraction> {
+        let mut sorted = events.clone();
+        sorted.sort();
+        let chunk_size: usize = <EventsBatchLimit as sp_core::Get<u32>>::get() as usize;
+        let mut fractions = Vec::<DiscoveredEthEventsFraction>::new();
+
+        let mut iter = sorted.chunks(chunk_size).enumerate();
+        let fraction_count = sorted.chunks(chunk_size).count() as u16;
+        let hash: H256 = blake2_256(&(&events, fraction_count).encode()).into();
+
+        let _ = iter.try_for_each(|(fraction, chunk)| -> Result<(), ()> {
+            let inner_data: BTreeSet<DiscoveredEvent> = chunk.iter().cloned().collect();
+            let data = EthEventsPartition::try_from(inner_data)?;
+            fractions.push(DiscoveredEthEventsFraction::new(
+                data,
+                fraction as u16,
+                fraction_count,
+                &hash,
+            ));
+            Ok(())
+        });
+        fractions
+    }
+}

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -20,6 +20,7 @@ pub const CLOSE_BYTES_TAG: &'static [u8] = b"</Bytes>";
 #[path = "tests/helpers.rs"]
 pub mod avn_tests_helpers;
 pub mod eth_key_actions;
+pub mod event_discovery;
 pub mod event_types;
 pub mod ocw_lock;
 


### PR DESCRIPTION
## Proposed changes

Introduces the data structures and the voting mechanism for accepting events ranges from ethereum.

Ranges that are too big will be broken down into smaller partitions, voted upon individually, and accepted as one.

Follow up commit will do the validate unsigned and processing of the partitions.

Jira tickets:
- SYS-3635
- SYS-3930
 

