### PR TITLE
SYS-3930: Implement Vote Processing

### DIFF
--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -29,7 +29,7 @@ use frame_system::{
 use sp_application_crypto::RuntimeAppPublic;
 use sp_avn_common::{
     bounds::MaximumValidatorsBound,
-    event_types::{EthEventId, Validator},
+    event_types::{EthEvent, EthEventId, Validator},
     ocw_lock::{self as OcwLock, OcwStorageError},
     recover_public_key_from_ecdsa_signature, DEFAULT_EXTERNAL_SERVICE_PORT_NUMBER,
     EXTERNAL_SERVICE_PORT_NUMBER_KEY,
@@ -695,6 +695,9 @@ pub trait BridgeInterfaceNotification {
     fn process_lower_proof_result(_: u32, _: Vec<u8>, _: Result<Vec<u8>, ()>) -> DispatchResult {
         Ok(())
     }
+    fn on_event_processed(_event: &EthEvent) -> DispatchResult {
+        Ok(())
+    }
 }
 
 #[impl_trait_for_tuples::impl_for_tuples(30)]
@@ -710,6 +713,11 @@ impl BridgeInterfaceNotification for Tuple {
         _encoded_lower: Result<Vec<u8>, ()>,
     ) -> DispatchResult {
         for_tuples!( #( Tuple::process_lower_proof_result(_lower_id, _caller_id.clone(), _encoded_lower.clone())?; )* );
+        Ok(())
+    }
+
+    fn on_event_processed(_event: &EthEvent) -> DispatchResult {
+        for_tuples!( #( Tuple::on_event_processed(_event)?; )* );
         Ok(())
     }
 }

--- a/pallets/eth-bridge/src/call.rs
+++ b/pallets/eth-bridge/src/call.rs
@@ -34,6 +34,15 @@ pub fn add_corroboration<T: Config>(
     let _ = SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into());
 }
 
+pub fn submit_ethereum_events<T: Config>(
+    author: Author<T>,
+    events_partition: EthereumEventsPartition,
+    signature: <T::AuthorityId as RuntimeAppPublic>::Signature,
+) -> Result<(), ()> {
+    let call = Call::<T>::submit_ethereum_events { author, events_partition, signature };
+    SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into())
+}
+
 fn add_confirmation_proof<T: Config>(
     tx_id: EthereumId,
     confirmation: &ecdsa::Signature,
@@ -57,4 +66,11 @@ fn add_corroboration_proof<T: Config>(
     account_id: &T::AccountId,
 ) -> Vec<u8> {
     (ADD_CORROBORATION_CONTEXT, tx_id, tx_succeeded, tx_hash_is_valid, &account_id).encode()
+}
+
+pub fn create_ethereum_events_proof_data<T: Config>(
+    account_id: &T::AccountId,
+    events_partition: &EthereumEventsPartition,
+) -> Vec<u8> {
+    (SUBMIT_ETHEREUM_EVENTS_HASH_CONTEXT, &account_id, events_partition).encode()
 }

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -535,7 +535,7 @@ pub mod pallet {
 
             if active_range.is_initial_range() == false {
                 ensure!(
-                    has_author_casted_event_vote::<T>(&author.account_id) == false,
+                    author_has_cast_event_vote::<T>(&author.account_id) == false,
                     Error::<T>::EventVoteExists
                 );
             }
@@ -670,7 +670,7 @@ pub mod pallet {
 
         Ok(())
     }
-    fn has_author_casted_event_vote<T: Config>(author: &T::AccountId) -> bool {
+    fn author_has_cast_event_vote<T: Config>(author: &T::AccountId) -> bool {
         for (_partition, votes) in EthereumEvents::<T>::iter() {
             if votes.contains(&author) {
                 return true
@@ -714,7 +714,7 @@ pub mod pallet {
                         log::warn!("Ethereum event signature ({:?}) included in approved range ({:?}), but not part of the expected ones {:?}", &discovered_event.event.event_id.signature, active_range.range, active_range.event_types_filter);
                     },
                 None => log::warn!(
-                    "Unknown signature in range: {:?}",
+                    "Unknown Ethereum event signature in range {:?}",
                     &discovered_event.event.event_id.signature
                 ),
             };

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -88,6 +88,8 @@ mod types;
 mod util;
 use crate::types::*;
 
+pub use call::{create_ethereum_events_proof_data, submit_ethereum_events};
+
 mod benchmarking;
 #[cfg(test)]
 #[path = "tests/lower_proof_tests.rs"]

--- a/pallets/eth-bridge/src/types.rs
+++ b/pallets/eth-bridge/src/types.rs
@@ -1,4 +1,7 @@
 use crate::*;
+use sp_avn_common::event_types::ValidEvents;
+type EventsTypesLimit = ConstU32<20>;
+type EthBridgeEventsFilter = BoundedBTreeSet<ValidEvents, EventsTypesLimit>;
 
 // The different types of request this pallet can handle.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
@@ -126,20 +129,15 @@ pub struct ActiveEthTransaction<T: Config> {
     pub tx_succeeded: bool,
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
-pub enum EventProcessingStatus {
-    UnderValidation,
-    Accepted(FractionsCount),
-}
-
-impl Default for EventProcessingStatus {
-    fn default() -> Self {
-        EventProcessingStatus::UnderValidation
-    }
-}
-
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]
 pub struct ActiveEthRange {
     pub range: EthBlockRange,
-    pub status: EventProcessingStatus,
+    pub partition: u16,
+    pub event_types_filter: EthBridgeEventsFilter,
+}
+
+impl ActiveEthRange {
+    pub fn is_initial_range(&self) -> bool {
+        *self == Default::default()
+    }
 }

--- a/pallets/eth-bridge/src/types.rs
+++ b/pallets/eth-bridge/src/types.rs
@@ -125,3 +125,21 @@ pub struct ActiveEthTransaction<T: Config> {
     pub invalid_tx_hash_corroborations: BoundedVec<T::AccountId, ConfirmationsLimit>,
     pub tx_succeeded: bool,
 }
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
+pub enum EventProcessingStatus {
+    UnderValidation,
+    Accepted(FractionsCount),
+}
+
+impl Default for EventProcessingStatus {
+    fn default() -> Self {
+        EventProcessingStatus::UnderValidation
+    }
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]
+pub struct ActiveEthRange {
+    pub range: EthBlockRange,
+    pub status: EventProcessingStatus,
+}

--- a/primitives/avn-common/src/event_types.rs
+++ b/primitives/avn-common/src/event_types.rs
@@ -56,7 +56,7 @@ pub enum Error {
     AvtGrowthLiftedEventPeriodConversion,
 }
 
-#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialOrd, Ord, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 pub enum ValidEvents {
     AddedValidator,
     Lifted,


### PR DESCRIPTION
## Proposed changes

This PR introduces support for processing votes upon achieving consensus. It extends extrinsics and data structures accordingly.

Once the final vote is cast, the voting round for the Ethereum range partition is finalized, and the partition is processed.

Additionally, this PR extends the subscription mechanism of the eth-bridge pallet. By default, pallets ignore processed events, requiring the implementation of a handler to process them.
Benchmarking for certain actions will be addressed in a separate PR.

Jira Tasks:
- SYS-3930
- SYS-3635
