### PR TITLE
SYS-3955 Improve length comparison

### DIFF
--- a/node/avn-service/src/keystore_utils.rs
+++ b/node/avn-service/src/keystore_utils.rs
@@ -16,7 +16,7 @@ pub fn get_eth_address_bytes_from_keystore(keystore_path: &PathBuf) -> Result<Ve
         ))
     })?;
 
-    if addresses.len() == 0 {
+    if addresses.is_empty() {
         Err(server_error(format!("No keys found in the keystore for {:?}", ETHEREUM_SIGNING_KEY)))?
     }
 

--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -258,7 +258,7 @@ impl<T: Config> Pallet<T> {
         let validators = Self::validators();
 
         // If there are no validators there's no point continuing
-        if validators.len() == 0 {
+        if validators.is_empty() {
             return Err(Error::<T>::NoValidatorsFound)
         }
 

--- a/pallets/ethereum-events/src/lib.rs
+++ b/pallets/ethereum-events/src/lib.rs
@@ -1374,7 +1374,7 @@ impl<T: Config> Pallet<T> {
             parse_response_to_json(response_body.expect("Checked for error."))
                 .unwrap_or((vec![], 0));
 
-        if response_data_object.len() == 0 {
+        if response_data_object.is_empty() {
             log::error!("❌ Response data json is empty");
             return invalid_result
         };

--- a/pallets/ethereum-events/src/tests/test_process_event.rs
+++ b/pallets/ethereum-events/src/tests/test_process_event.rs
@@ -1277,7 +1277,7 @@ mod process_event {
     }
 
     fn there_are_no_pending_events() -> bool {
-        return EthereumEvents::events_pending_challenge().len() == 0
+        return EthereumEvents::events_pending_challenge().is_empty()
     }
 
     fn event_is_in_processed_list(context: &Context) -> bool {


### PR DESCRIPTION
From the auditors: 
```
The team identified that the application is using ".len()" and compares the return value with zero (0) to check if an array is empty. However, this is a more costly operation than using the faster ".is_empty()" function call.
```