### PR TITLE
Introduces initial range consesnus mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7197,7 +7197,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge-runtime-api"
-version = "5.2.2"
+version = "5.2.3"
 dependencies = [
  "frame-support",
  "pallet-avn",

--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -141,7 +141,7 @@ pub enum AppError {
     MissingBlockNumber,
     MissingEventSignature,
     ParsingError(Error),
-    GenericError(String)
+    GenericError(String),
 }
 
 pub async fn identify_events(

--- a/node/src/common.rs
+++ b/node/src/common.rs
@@ -31,7 +31,7 @@ pub trait AvnRuntimeApiCollection:
     + pallet_eth_bridge_runtime_api::EthEventHandlerApi<BlockT, AccountId>
 where
     <Self as sp_api::ApiExt<BlockT>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
-    AccountId: Codec
+    AccountId: Codec,
 {
 }
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -300,24 +300,25 @@ where
             keystore: params.keystore_container.local_keystore(),
             keystore_path: keystore_path.clone(),
             avn_port: avn_port.clone(),
-            eth_node_url:eth_node_url.clone(),
+            eth_node_url: eth_node_url.clone(),
             web3_data_mutex: Arc::new(Mutex::new(Web3Data::new())),
             client: client.clone(),
             _block: Default::default(),
         };
 
-        let eth_event_handler_config = avn_service::ethereum_events_handler::EthEventHandlerConfig::<Block, _> {
-            keystore: params.keystore_container.local_keystore(),
-            keystore_path: keystore_path.clone(),
-            avn_port: avn_port.clone(),
-            eth_node_url:eth_node_url.clone(),
-            web3_data_mutex: Arc::new(Mutex::new(Web3Data::new())),
-            client: client.clone(),
-            _block: Default::default(),
-            offchain_transaction_pool_factory: OffchainTransactionPoolFactory::new(
-                transaction_pool.clone(),
-            ),
-        };
+        let eth_event_handler_config =
+            avn_service::ethereum_events_handler::EthEventHandlerConfig::<Block, _> {
+                keystore: params.keystore_container.local_keystore(),
+                keystore_path: keystore_path.clone(),
+                avn_port: avn_port.clone(),
+                eth_node_url: eth_node_url.clone(),
+                web3_data_mutex: Arc::new(Mutex::new(Web3Data::new())),
+                client: client.clone(),
+                _block: Default::default(),
+                offchain_transaction_pool_factory: OffchainTransactionPoolFactory::new(
+                    transaction_pool.clone(),
+                ),
+            };
 
         task_manager.spawn_essential_handle().spawn(
             "avn-service",

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -515,8 +515,9 @@ pub mod pallet {
             Ok(().into())
         }
 
+        // TODO update weights
         #[pallet::call_index(6)]
-        #[pallet::weight(<T as Config>::WeightInfo::add_eth_tx_hash())]
+        #[pallet::weight(Weight::zero())]
         pub fn submit_ethereum_events(
             origin: OriginFor<T>,
             author: Author<T>,
@@ -550,8 +551,9 @@ pub mod pallet {
             Ok(().into())
         }
 
+        // TODO update weights
         #[pallet::call_index(7)]
-        #[pallet::weight(<T as Config>::WeightInfo::add_eth_tx_hash())]
+        #[pallet::weight(Weight::zero())]
         pub fn submit_latest_ethereum_block(
             origin: OriginFor<T>,
             author: Author<T>,
@@ -559,7 +561,7 @@ pub mod pallet {
             _signature: <T::AuthorityId as RuntimeAppPublic>::Signature,
         ) -> DispatchResultWithPostInfo {
             ensure_none(origin)?;
-            ensure!(Self::active_ethereum_range().is_some(), Error::<T>::VotingEnded);
+            ensure!(Self::active_ethereum_range().is_none(), Error::<T>::VotingEnded);
             ensure!(
                 author_has_cast_event_vote::<T>(&author.account_id) == false,
                 Error::<T>::EventVoteExists

--- a/primitives/avn-common/src/event_discovery.rs
+++ b/primitives/avn-common/src/event_discovery.rs
@@ -8,7 +8,9 @@ use sp_runtime::traits::Saturating;
 pub type VotesLimit = ConstU32<100>;
 pub type EventsBatchLimit = ConstU32<32>;
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Encode, Decode, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default, TypeInfo, MaxEncodedLen,
+)]
 pub struct EthBlockRange {
     pub start_block: u32,
     pub length: u32,
@@ -140,5 +142,16 @@ pub mod events_helpers {
                     Ok(())
                 });
         partitions
+    }
+
+    // TODO unit test this
+    pub fn compute_finalised_block_range_for_latest_ethereum_block(
+        ethereum_block: u32,
+    ) -> EthBlockRange {
+        let length = 20u32;
+        let calculation_block = ethereum_block - 5 * length;
+        let start_block = calculation_block - calculation_block % length;
+
+        EthBlockRange { start_block, length }
     }
 }

--- a/primitives/avn-common/src/event_discovery.rs
+++ b/primitives/avn-common/src/event_discovery.rs
@@ -149,7 +149,7 @@ pub mod events_helpers {
         ethereum_block: u32,
     ) -> EthBlockRange {
         let length = 20u32;
-        let calculation_block = ethereum_block - 5 * length;
+        let calculation_block = ethereum_block.saturating_sub(5 * length);
         let start_block = calculation_block - calculation_block % length;
 
         EthBlockRange { start_block, length }

--- a/primitives/avn-common/src/event_types.rs
+++ b/primitives/avn-common/src/event_types.rs
@@ -4,7 +4,7 @@ use hex_literal::hex;
 use sp_core::{bounded::BoundedVec, H160, H256, H512, U256};
 use sp_runtime::{
     scale_info::TypeInfo,
-    traits::{Member, Zero},
+    traits::Member,
     DispatchResult,
 };
 use sp_std::{convert::TryInto, vec::Vec};

--- a/primitives/avn-common/src/event_types.rs
+++ b/primitives/avn-common/src/event_types.rs
@@ -2,11 +2,7 @@ use crate::bounds::NftExternalRefBound;
 use codec::{Decode, Encode, MaxEncodedLen};
 use hex_literal::hex;
 use sp_core::{bounded::BoundedVec, H160, H256, H512, U256};
-use sp_runtime::{
-    scale_info::TypeInfo,
-    traits::Member,
-    DispatchResult,
-};
+use sp_runtime::{scale_info::TypeInfo, traits::Member, DispatchResult};
 use sp_std::{convert::TryInto, vec::Vec};
 
 // ================================= Events Types ====================================

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -68,7 +68,10 @@ use pallet_avn::sr25519::AuthorityId as AvnId;
 
 pub use pallet_avn_proxy::{Event as AvnProxyEvent, ProvableProxy};
 use pallet_avn_transaction_payment::AvnCurrencyAdapter;
-use sp_avn_common::{event_discovery::{EthBlockRange, EthereumEventsPartition}, InnerCallValidator, Proof};
+use sp_avn_common::{
+    event_discovery::{EthBlockRange, EthereumEventsPartition},
+    InnerCallValidator, Proof,
+};
 
 use pallet_parachain_staking;
 pub type NegativeImbalance<T> = <pallet_balances::Pallet<T> as Currency<


### PR DESCRIPTION
## Proposed changes

Adds a new endpoint that allows the chain to reach consenus over the initial ethereum range to be used.
This allows to simplify the voting logic for active ranges, eliminating the special case of the first range.

