### PR TITLE
SYS-3930 Cleanup and finalises interface with runtime

### DIFF
--- a/pallets/eth-bridge/src/tests/event_listener_tests.rs
+++ b/pallets/eth-bridge/src/tests/event_listener_tests.rs
@@ -323,7 +323,7 @@ mod initial_range_consensus {
 
     fn get_votes_for_range(range: &EthBlockRange) -> usize {
         let mut votes_count = 0usize;
-        SubmittedBlockNumbers::<TestRuntime>::iter().for_each(|(voted_range, _votes)| {
+        SubmittedBlockRanges::<TestRuntime>::iter().for_each(|(voted_range, _votes)| {
             if voted_range == range.clone() {
                 votes_count.saturating_inc();
             }
@@ -366,6 +366,10 @@ mod initial_range_consensus {
                 active_range.range,
                 events_helpers::compute_finalised_block_range_for_latest_ethereum_block(300)
             );
+            // Ensure that cleanup has occured
+            for context in contexts.iter() {
+                assert_eq!(get_votes_for_range(&context.range()), 0, "Should be no votes.");
+            }
         });
     }
 

--- a/pallets/eth-bridge/src/tests/mock.rs
+++ b/pallets/eth-bridge/src/tests/mock.rs
@@ -100,6 +100,7 @@ impl Config for TestRuntime {
     type AccountToBytesConvert = U64To32BytesConverter;
     type BridgeInterfaceNotification = TestRuntime;
     type ReportCorroborationOffence = OffenceHandler;
+    type EthereumEventsFilter = ();
 }
 
 impl system::Config for TestRuntime {

--- a/pallets/eth-bridge/src/types.rs
+++ b/pallets/eth-bridge/src/types.rs
@@ -1,7 +1,5 @@
 use crate::*;
-use sp_avn_common::event_types::ValidEvents;
-type EventsTypesLimit = ConstU32<20>;
-type EthBridgeEventsFilter = BoundedBTreeSet<ValidEvents, EventsTypesLimit>;
+use sp_avn_common::event_discovery::EthBridgeEventsFilter;
 
 // The different types of request this pallet can handle.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]

--- a/pallets/summary/src/tests/mock.rs
+++ b/pallets/summary/src/tests/mock.rs
@@ -352,6 +352,7 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type AccountToBytesConvert = AVN;
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = OffenceHandler;
+    type EthereumEventsFilter = ();
 }
 
 impl pallet_timestamp::Config for TestRuntime {

--- a/primitives/avn-common/src/event_discovery.rs
+++ b/primitives/avn-common/src/event_discovery.rs
@@ -5,6 +5,8 @@ use event_types::EthEvent;
 use sp_core::{bounded::BoundedBTreeSet, ConstU32};
 use sp_runtime::traits::Saturating;
 
+use self::event_types::ValidEvents;
+
 pub type VotesLimit = ConstU32<100>;
 pub type EventsBatchLimit = ConstU32<32>;
 
@@ -102,6 +104,19 @@ impl EthereumEventsPartition {
 
     fn new(range: EthBlockRange, partition: u16, is_last: bool, data: EthereumEventsSet) -> Self {
         EthereumEventsPartition { range, partition, is_last, data }
+    }
+}
+
+pub type EventsTypesLimit = ConstU32<20>;
+pub type EthBridgeEventsFilter = BoundedBTreeSet<ValidEvents, EventsTypesLimit>;
+
+pub trait EthereumEventsFilterTrait {
+    fn get_filter() -> EthBridgeEventsFilter;
+}
+
+impl EthereumEventsFilterTrait for () {
+    fn get_filter() -> EthBridgeEventsFilter {
+        Default::default()
     }
 }
 

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -639,6 +639,7 @@ impl pallet_eth_bridge::Config for Runtime {
     type ReportCorroborationOffence = Offences;
     type WeightInfo = pallet_eth_bridge::default_weights::SubstrateWeight<Runtime>;
     type BridgeInterfaceNotification = (Summary, TokenManager, ParachainStaking);
+    type EthereumEventsFilter = ();
 }
 
 // Other pallets

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -24,6 +24,8 @@ use sp_runtime::{
     transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
     ApplyExtrinsicResult,
 };
+pub extern crate alloc;
+use alloc::collections::BTreeSet;
 
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -67,7 +69,11 @@ use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use pallet_avn::sr25519::AuthorityId as AvnId;
 
 use pallet_avn_proxy::ProvableProxy;
-use sp_avn_common::{InnerCallValidator, Proof};
+use sp_avn_common::{
+    event_discovery::{EthBridgeEventsFilter, EthereumEventsFilterTrait},
+    event_types::ValidEvents,
+    InnerCallValidator, Proof,
+};
 
 use pallet_parachain_staking;
 pub type NegativeImbalance<T> = <pallet_balances::Pallet<T> as Currency<
@@ -105,6 +111,22 @@ where
             }
             <ToStakingPot<R> as OnUnbalanced<_>>::on_unbalanced(fees);
         }
+    }
+}
+
+pub struct EthBridgeTestRuntimeEventsFilter;
+impl EthereumEventsFilterTrait for EthBridgeTestRuntimeEventsFilter {
+    fn get_filter() -> EthBridgeEventsFilter {
+        let allowed_events: BTreeSet<ValidEvents> = vec![
+            ValidEvents::AddedValidator,
+            ValidEvents::Lifted,
+            ValidEvents::AvtGrowthLifted,
+            ValidEvents::AvtLowerClaimed,
+        ]
+        .into_iter()
+        .collect();
+
+        EthBridgeEventsFilter::try_from(allowed_events).unwrap_or_default()
     }
 }
 
@@ -645,6 +667,7 @@ impl pallet_eth_bridge::Config for Runtime {
     type TimeProvider = pallet_timestamp::Pallet<Runtime>;
     type WeightInfo = pallet_eth_bridge::default_weights::SubstrateWeight<Runtime>;
     type BridgeInterfaceNotification = (Summary, TokenManager, ParachainStaking);
+    type EthereumEventsFilter = EthBridgeTestRuntimeEventsFilter;
 }
 
 // Other pallets


### PR DESCRIPTION
## Proposed changes

- General cleanup
- Rename of storage items
- Removal of mocks
- Wire up with runtime, implementing different events filters for each runtime.
