### PR TITLE
fix: refactored getting the authors to verify current node's author

### DIFF
--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -360,6 +360,8 @@ where
     let author_public_key =
         config.client.runtime_api().query_authors(config.client.info().best_hash);
 
+    log::info!("HELP !!! AUTHOR: {:?}, PUBLIC: {:?}", author_public_key,public_keys);
+    
     let current_public_key = match find_author_account_id(author_public_key, public_keys) {
         Some(key) => key,
         None => {

--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -358,13 +358,13 @@ where
     );
 
     let author_public_keys =
-        config.client.runtime_api().query_authors(config.client.info().best_hash)
+        config.client.runtime_api().query_author_signing_keys(config.client.info().best_hash)
         .map_err(|e|{
             log::error!("Error querying authors: {:?}", e);
         })
         .and_then(|opt_keys| match opt_keys {
             Some(keys)=>Ok(keys),
-            None => todo!(),
+            None => Err(()),
         });
 
     let current_node_public_key = match find_author_account_id(author_public_keys, public_keys) {

--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -321,7 +321,6 @@ fn find_author_account_id<T>(
     if let Ok(account_ids) = author_public_keys {
         let signer_keys: Vec<Public> = account_ids.iter().map(|a|Public::from_raw(*a)).collect();
         for key in keystore_public_keys {
-            log::info!("HELP !!! AUTHOR: {:?}, PUBLIC: {:?}", signer_keys,key);
             if signer_keys.contains(&key) {
                 return Some(key)
             }

--- a/pallets/eth-bridge/runtime-api/src/lib.rs
+++ b/pallets/eth-bridge/runtime-api/src/lib.rs
@@ -11,7 +11,7 @@ sp_api::decl_runtime_apis! {
             where
         AccountId: Codec,
     {
-        fn query_authors() -> Vec<AccountId>;
+        fn query_authors() -> Option<Vec<[u8; 32]>>;
         fn query_active_block_range()-> Option<(EthBlockRange, u16)>;
         fn query_has_author_casted_vote(account_id: AccountId) -> bool;
         fn query_signatures() -> Vec<H256>;

--- a/pallets/eth-bridge/runtime-api/src/lib.rs
+++ b/pallets/eth-bridge/runtime-api/src/lib.rs
@@ -11,7 +11,7 @@ sp_api::decl_runtime_apis! {
             where
         AccountId: Codec,
     {
-        fn query_authors() -> Option<Vec<[u8; 32]>>;
+        fn query_author_signing_keys() -> Option<Vec<[u8; 32]>>;
         fn query_active_block_range()-> Option<(EthBlockRange, u16)>;
         fn query_has_author_casted_vote(account_id: AccountId) -> bool;
         fn query_signatures() -> Vec<H256>;

--- a/pallets/eth-bridge/runtime-api/src/lib.rs
+++ b/pallets/eth-bridge/runtime-api/src/lib.rs
@@ -11,7 +11,7 @@ sp_api::decl_runtime_apis! {
             where
         AccountId: Codec,
     {
-        fn query_current_author() -> Option<AccountId>;
+        fn query_authors() -> Vec<AccountId>;
         fn query_active_block_range()-> Option<(EthBlockRange, u16)>;
         fn query_has_author_casted_vote(account_id: AccountId) -> bool;
         fn query_signatures() -> Vec<H256>;

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -177,7 +177,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 64,
+    spec_version: 60,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -15,6 +15,9 @@ use core::cmp::Ordering;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
+// use sp_application_crypto::RuntimePublic;
+use sp_runtime::RuntimeAppPublic;
+
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, ConstU128, OpaqueMetadata, H160};
@@ -22,8 +25,10 @@ use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
     traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto},
     transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult,
+    ApplyExtrinsicResult, WeakBoundedVec,
 };
+
+use pallet_eth_bridge::Author;
 
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -50,9 +55,15 @@ use proxy_config::AvnProxyConfig;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 pub use sp_runtime::{MultiAddress, Perbill, Permill};
 use xcm_config::{XcmConfig, XcmOriginToTransactDispatchOrigin};
+use sp_core::sr25519::Public;
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
+
+use sp_avn_common::{
+    bounds::MaximumValidatorsBound,
+    event_types::Validator,
+};
 
 // Polkadot imports
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
@@ -946,11 +957,14 @@ impl_runtime_apis! {
     }
 
     impl pallet_eth_bridge_runtime_api::EthEventHandlerApi<Block, AccountId> for Runtime {
-        fn query_authors() -> Vec<AccountId> {
-            let validators_data = Avn::validators();
-            validators_data.iter()
-            .map(|validator| validator.account_id.clone())
-            .collect()
+        fn query_authors() ->Option<Vec<[u8; 32]>> {
+            let validators = Avn::validators().to_vec();
+            let res = validators.iter().map(|validator| {
+                let mut key: [u8; 32] = Default::default();
+                key.copy_from_slice(&validator.key.to_raw_vec()[0..32]);
+                return Some(key)
+            }).collect();
+            return res
         }
 
         fn query_active_block_range()-> Option<(EthBlockRange, u16)> {

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -15,7 +15,6 @@ use core::cmp::Ordering;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
-// use sp_application_crypto::RuntimePublic;
 use sp_runtime::RuntimeAppPublic;
 
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
@@ -957,7 +956,7 @@ impl_runtime_apis! {
     }
 
     impl pallet_eth_bridge_runtime_api::EthEventHandlerApi<Block, AccountId> for Runtime {
-        fn query_authors() ->Option<Vec<[u8; 32]>> {
+        fn query_author_signing_keys() ->Option<Vec<[u8; 32]>> {
             let validators = Avn::validators().to_vec();
             let res = validators.iter().map(|validator| {
                 let mut key: [u8; 32] = Default::default();

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -946,9 +946,11 @@ impl_runtime_apis! {
     }
 
     impl pallet_eth_bridge_runtime_api::EthEventHandlerApi<Block, AccountId> for Runtime {
-        fn query_current_author() -> Option<AccountId>{
-            Avn::get_validator_for_current_node()
-                .map(|validator| validator.account_id)
+        fn query_authors() -> Vec<AccountId> {
+            let validators_data = Avn::validators();
+            validators_data.iter()
+            .map(|validator| validator.account_id.clone())
+            .collect()
         }
 
         fn query_active_block_range()-> Option<(EthBlockRange, u16)> {

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -966,9 +966,11 @@ impl_runtime_apis! {
     }
 
     impl pallet_eth_bridge_runtime_api::EthEventHandlerApi<Block, AccountId> for Runtime {
-        fn query_current_author() -> Option<AccountId>{
-            Avn::get_validator_for_current_node()
-                .map(|validator| validator.account_id)
+        fn query_authors() -> Vec<AccountId> {
+            let validators_data = Avn::validators();
+            validators_data.iter()
+            .map(|validator| validator.account_id.clone())
+            .collect()
         }
 
         fn query_active_block_range()-> Option<(EthBlockRange, u16)> {

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -14,6 +14,10 @@ use core::cmp::Ordering;
 
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
+use sp_core::sr25519::Public;
+
+// use sp_application_crypto::RuntimePublic;
+use sp_runtime::RuntimeAppPublic;
 
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 use sp_api::impl_runtime_apis;
@@ -837,6 +841,8 @@ mod benches {
     );
 }
 
+use pallet_eth_bridge::Author;
+
 impl_runtime_apis! {
     impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
         fn slot_duration() -> sp_consensus_aura::SlotDuration {
@@ -966,11 +972,14 @@ impl_runtime_apis! {
     }
 
     impl pallet_eth_bridge_runtime_api::EthEventHandlerApi<Block, AccountId> for Runtime {
-        fn query_authors() -> Vec<AccountId> {
-            let validators_data = Avn::validators();
-            validators_data.iter()
-            .map(|validator| validator.account_id.clone())
-            .collect()
+        fn query_authors() -> Option<Vec<[u8; 32]>>{
+            let validators = Avn::validators().to_vec();
+            let res = validators.iter().map(|validator| {
+                let mut key: [u8; 32] = Default::default();
+                key.copy_from_slice(&validator.key.to_raw_vec()[0..32]);
+                return Some(key)
+            }).collect();
+            return res
         }
 
         fn query_active_block_range()-> Option<(EthBlockRange, u16)> {

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -16,7 +16,6 @@ use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_core::sr25519::Public;
 
-// use sp_application_crypto::RuntimePublic;
 use sp_runtime::RuntimeAppPublic;
 
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
@@ -972,7 +971,7 @@ impl_runtime_apis! {
     }
 
     impl pallet_eth_bridge_runtime_api::EthEventHandlerApi<Block, AccountId> for Runtime {
-        fn query_authors() -> Option<Vec<[u8; 32]>>{
+        fn query_author_signing_keys() -> Option<Vec<[u8; 32]>>{
             let validators = Avn::validators().to_vec();
             let res = validators.iter().map(|validator| {
                 let mut key: [u8; 32] = Default::default();


### PR DESCRIPTION
instead of `getting the author for current node`, as it requires `externalities`, we are exposing the `validators` storage item to iterate through to find the correct keystore public key