### PR TITLE
fix: Make avn-event-handler service more faullt tollerant

### DIFF
--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -75,11 +75,7 @@ use pallet_session::historical::IdentificationTuple;
 use sp_staking::offence::ReportOffence;
 
 use sp_application_crypto::RuntimeAppPublic;
-use sp_avn_common::{
-    bounds::MaximumValidatorsBound,
-    event_discovery::*,
-    event_types::{Validator},
-};
+use sp_avn_common::{bounds::MaximumValidatorsBound, event_discovery::*, event_types::Validator};
 use sp_core::{ecdsa, ConstU32, H160, H256};
 use sp_io::hashing::keccak_256;
 use sp_runtime::{scale_info::TypeInfo, traits::Dispatchable, Saturating};
@@ -811,10 +807,10 @@ pub mod pallet {
                 Some(valid_event) =>
                     if active_range.event_types_filter.contains(&valid_event) {
                         if process_ethereum_event::<T>(&discovered_event.event).is_err() {
-                                log::error!("💔 Duplicate Event Submission");
-                                <Pallet<T>>::deposit_event(Event::<T>::DuplicateEventSubmission {
-                                    eth_event_id: discovered_event.event.event_id.clone(),
-                                });
+                            log::error!("💔 Duplicate Event Submission");
+                            <Pallet<T>>::deposit_event(Event::<T>::DuplicateEventSubmission {
+                                eth_event_id: discovered_event.event.event_id.clone(),
+                            });
                         }
                     } else {
                         log::warn!("Ethereum event signature ({:?}) included in approved range ({:?}), but not part of the expected ones {:?}", &discovered_event.event.event_id.signature, active_range.range, active_range.event_types_filter);

--- a/pallets/eth-bridge/src/tests/incoming_events_tests.rs
+++ b/pallets/eth-bridge/src/tests/incoming_events_tests.rs
@@ -131,9 +131,11 @@ mod process_events {
                 context.test_signature_two.clone()
             ));
             assert!(System::events().iter().any(|record| record.event ==
-                mock::RuntimeEvent::EthBridge(Event::<TestRuntime>::DuplicateEventSubmission {
-                    eth_event_id: context.eth_event_id.clone(),
-                })));
+                mock::RuntimeEvent::EthBridge(
+                    Event::<TestRuntime>::DuplicateEventSubmission {
+                        eth_event_id: context.eth_event_id.clone(),
+                    }
+                )));
         });
     }
 }


### PR DESCRIPTION
This commit allows the avn-event-hanlder to handle more graceful error.
Also applies code formatting.
