### PR TITLE
fix: container image generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ RUN apt-get update && \
 	apt-get autoremove -y && \
 	apt-get clean && \
 	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
-	# add user and link ~/.local/share/avn-node to /data
+	# add user and link ~/.local/share/avn-parachain-collator to /data
 	useradd -m -u 1000 -U -s /bin/sh -d /avn-node avn-node && \
 	mkdir -p /data /avn-node/.local/share && \
 	chown -R avn-node:avn-node /data && \
-	ln -s /data /avn-node/.local/share/avn-node && \
+	ln -s /data /avn-node/.local/share/avn-parachain-collator && \
 	mkdir -p /specs
 
 # add avn-node binary to the docker image

--- a/Dockerfile.22_04
+++ b/Dockerfile.22_04
@@ -28,11 +28,11 @@ RUN apt-get update && \
 	apt-get autoremove -y && \
 	apt-get clean && \
 	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
-	# add user and link ~/.local/share/avn-node to /data
+	# add user and link ~/.local/share/avn-parachain-collator to /data
 	useradd -m -u 1000 -U -s /bin/sh -d /avn-node avn-node && \
 	mkdir -p /data /avn-node/.local/share && \
 	chown -R avn-node:avn-node /data && \
-	ln -s /data /avn-node/.local/share/avn-node && \
+	ln -s /data /avn-node/.local/share/avn-parachain-collator && \
 	mkdir -p /specs
 
 # add avn-node binary to the docker image


### PR DESCRIPTION
Fixes an issues with the container image generation, where the wrong path was used as the default execution path, leading to some errors when the node was trying to access the /data storage, resulting to this error:

`Os { code: 13, kind: PermissionDenied, message: \\"Permission denied\\"}`

## Proposed changes

<!---Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.-->

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
