### PR TITLE
SYS-3635 deprecate ethreum events entrypoints

### DIFF
--- a/pallets/ethereum-events/src/lib.rs
+++ b/pallets/ethereum-events/src/lib.rs
@@ -425,7 +425,8 @@ pub mod pallet {
         // We need to maintain this till SYS-888 is resolved. After that it can be removed.
         #[deprecated(
             since = "5.5.0",
-            note = "This extrinsic is being deprecated. Use add_ethereum_log"
+            note = "This extrinsic is being deprecated and will be removed in the near future. Ethereum events will be automatically imported by EthBridge pallet.
+            Alternatively `add_ethereum_log` can be used although it's also deprecated but will be retained for a longer period"
         )]
         #[pallet::call_index(0)]
         #[pallet::weight( <T as pallet::Config>::WeightInfo::add_validator_log
@@ -442,7 +443,8 @@ pub mod pallet {
         // We need to maintain this till SYS-888 is resolved. After that it can be removed.
         #[deprecated(
             since = "5.5.0",
-            note = "This extrinsic is being deprecated. Use add_ethereum_log"
+            note = "This extrinsic is being deprecated and will be removed in the near future. Ethereum events will be automatically imported by EthBridge pallet.
+            Alternatively `add_ethereum_log` can be used although it's also deprecated but will be retained for a longer period"
         )]
         #[pallet::call_index(1)]
         #[pallet::weight( <T as pallet::Config>::WeightInfo::add_lift_log(

--- a/pallets/ethereum-events/src/lib.rs
+++ b/pallets/ethereum-events/src/lib.rs
@@ -422,8 +422,11 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        /// This extrinsic is being deprecated. Use add_ethereum_log
         // We need to maintain this till SYS-888 is resolved. After that it can be removed.
+        #[deprecated(
+            since = "5.5.0",
+            note = "This extrinsic is being deprecated. Use add_ethereum_log"
+        )]
         #[pallet::call_index(0)]
         #[pallet::weight( <T as pallet::Config>::WeightInfo::add_validator_log
             (MAX_NUMBER_OF_UNCHECKED_EVENTS,
@@ -436,8 +439,11 @@ pub mod pallet {
             return Self::add_event(ValidEvents::AddedValidator, tx_hash, account_id)
         }
 
-        /// This extrinsic is being deprecated. Use add_ethereum_log
         // We need to maintain this till SYS-888 is resolved. After that it can be removed.
+        #[deprecated(
+            since = "5.5.0",
+            note = "This extrinsic is being deprecated. Use add_ethereum_log"
+        )]
         #[pallet::call_index(1)]
         #[pallet::weight( <T as pallet::Config>::WeightInfo::add_lift_log(
             MAX_NUMBER_OF_UNCHECKED_EVENTS,
@@ -687,6 +693,10 @@ pub mod pallet {
         }
 
         /// Submits an ethereum transaction hash into the chain
+        #[deprecated(
+            since = "5.5.0",
+            note = "This extrinsic is being deprecated, ethereum events will be automatically imported by EthBridge pallet."
+        )]
         #[pallet::call_index(5)]
         #[pallet::weight( <T as pallet::Config>::WeightInfo::add_ethereum_log(
             MAX_NUMBER_OF_UNCHECKED_EVENTS,


### PR DESCRIPTION
## Proposed changes

Deprecates ethereum-events entry points that add manually events in the system.
Moving forward the responsibility will be shifted to eth-bridge event scanning mechanism on Ethereum.
