### PR TITLE
SYS-3560 fix: ensures last block of a range is polled once

### DIFF
--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -21,7 +21,6 @@ use sp_block_builder::BlockBuilder;
 use sp_blockchain::HeaderBackend;
 use sp_core::{sr25519::Public, H256 as SpH256};
 use sp_keystore::Keystore;
-use sp_runtime::AccountId32;
 use std::{collections::HashMap, marker::PhantomData, time::Instant};
 pub use std::{path::PathBuf, sync::Arc};
 use tide::Error as TideError;
@@ -442,12 +441,8 @@ where
         Some((range, partition_id)) => {
             log::info!("Getting events for range starting at: {:?}", range.start_block);
 
-            if web3_utils::is_eth_block_finalised(
-                &web3_ref,
-                get_range_end_block(range).into(),
-                ETH_FINALITY,
-            )
-            .await?
+            if web3_utils::is_eth_block_finalised(&web3_ref, range.end_block() as u64, ETH_FINALITY)
+                .await?
             {
                 process_events(
                     &web3_ref,
@@ -468,10 +463,6 @@ where
     };
 
     Ok(())
-}
-
-fn get_range_end_block(range: &EthBlockRange) -> u32 {
-    range.start_block + range.length
 }
 
 async fn submit_latest_ethereum_block<Block, ClientT>(
@@ -579,8 +570,6 @@ where
     let contract_address_web3 = web3::types::H160::from_slice(&contract_address.to_fixed_bytes());
     let contract_addresses = vec![contract_address_web3];
 
-    let end_block = get_range_end_block(&range);
-
     let event_signatures = config
         .client
         .runtime_api()
@@ -607,8 +596,6 @@ where
             config,
             &event_signatures_web3,
             contract_addresses,
-            range.start_block,
-            end_block,
             partition_id,
             current_node_author,
             range,
@@ -625,8 +612,6 @@ async fn execute_event_processing<Block, ClientT>(
     config: &EthEventHandlerConfig<Block, ClientT>,
     event_signatures_web3: &[Web3H256],
     contract_addresses: Vec<H160>,
-    start_block: u32,
-    end_block: u32,
     partition_id: u16,
     current_node_author: &CurrentNodeAuthor,
     range: EthBlockRange,
@@ -644,8 +629,8 @@ where
 {
     let events = identify_events(
         web3,
-        start_block,
-        end_block,
+        range.start_block,
+        range.end_block(),
         contract_addresses,
         event_signatures_web3.to_vec(),
         events_registry,

--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -7,7 +7,7 @@ use sc_keystore::LocalKeystore;
 use sp_api::ApiExt;
 use sp_avn_common::{
     event_discovery::{
-        encode_eth_event_submission_data, events_helpers::discovered_eth_events_partition_factory,
+        encode_eth_event_submission_data, events_helpers::EthereumEventsPartitionFactory,
         DiscoveredEvent, EthBlockRange, EthereumEventsPartition,
     },
     event_types::{
@@ -638,7 +638,8 @@ where
     .await
     .map_err(|err| format!("Error retrieving events: {:?}", err))?;
 
-    let ethereum_events_partitions = discovered_eth_events_partition_factory(range, events);
+    let ethereum_events_partitions =
+        EthereumEventsPartitionFactory::create_partitions(range, events);
     let partition = ethereum_events_partitions
         .iter()
         .find(|p| p.partition() == partition_id)

--- a/pallets/eth-bridge/src/migration.rs
+++ b/pallets/eth-bridge/src/migration.rs
@@ -5,8 +5,6 @@ use frame_support::{
     weights::Weight,
 };
 
-use sp_std::vec;
-
 use crate::*;
 
 #[cfg(feature = "try-runtime")]

--- a/pallets/eth-bridge/src/tests/event_listener_tests.rs
+++ b/pallets/eth-bridge/src/tests/event_listener_tests.rs
@@ -99,7 +99,7 @@ impl DiscoveredEthContext {
         });
     }
     fn partitions(&self) -> Vec<EthereumEventsPartition> {
-        events_helpers::discovered_eth_events_partition_factory(
+        events_helpers::EthereumEventsPartitionFactory::create_partitions(
             self.range.clone(),
             self.discovered_events.clone(),
         )
@@ -318,13 +318,6 @@ impl LatestEthBlockContext {
                 self.discovered_block,
             ))
             .expect("Signature is signed")
-    }
-
-    fn range(&self) -> EthBlockRange {
-        EthBlockRange {
-            start_block: self.eth_start_block,
-            length: EthBlockRangeSize::<TestRuntime>::get(),
-        }
     }
 }
 

--- a/pallets/eth-bridge/src/tests/incoming_events_tests.rs
+++ b/pallets/eth-bridge/src/tests/incoming_events_tests.rs
@@ -1,21 +1,12 @@
 // Copyright 2023 Aventus Network Systems (UK) Ltd.
 
 #![cfg(test)]
-use crate::{eth::generate_send_calldata, mock::*, request::*, *};
-use frame_support::{
-    assert_err, assert_noop, assert_ok, dispatch::DispatchResultWithPostInfo, error::BadOrigin,
-};
-use sp_runtime::{testing::UintAuthorityId, DispatchError};
+use crate::{mock::*, *};
+use frame_support::assert_ok;
+use sp_runtime::DispatchError;
 pub extern crate alloc;
 use alloc::collections::BTreeSet;
 use sp_avn_common::{event_discovery::EthBridgeEventsFilter, event_types::ValidEvents};
-
-const ROOT_HASH: &str = "30b83f0d722d1d4308ab4660a72dbaf0a7392d5674eca3cd21d57256d42df7a0";
-const REWARDS: &[u8] = b"15043665996000000000";
-const AVG_STAKED: &[u8] = b"9034532443555111110000";
-const PERIOD: &[u8] = b"3";
-const T2_PUB_KEY: &str = "14aeac90dbd3573458f9e029eb2de122ee94f2f0bc5ee4b6c6c5839894f1a547";
-const T1_PUB_KEY: &str = "23d79f6492dddecb436333a5e7a4cfcc969f568e01283fa2964aae15327fb8a3b685a4d0f3ef9b3c2adb20f681dbc74b7f82c1cf8438d37f2c10e9c79591e9ea";
 
 // Added this function as in event_listener_tests to initialize the active event range
 fn init_active_range() {
@@ -38,7 +29,6 @@ fn init_active_range() {
 
 mod process_events {
     use super::*;
-    use sp_avn_common::event_types::EthEventId;
 
     // succesfully process the specified ethereum_event
     #[test]

--- a/primitives/avn-common/src/event_discovery.rs
+++ b/primitives/avn-common/src/event_discovery.rs
@@ -26,8 +26,11 @@ impl EthBlockRange {
         }
     }
     pub fn range(&self) -> (u32, u32) {
-        let end_block = self.start_block.saturating_add(self.length).saturating_less_one();
+        let end_block = self.end_block();
         (self.start_block, end_block)
+    }
+    pub fn end_block(&self) -> u32 {
+        self.start_block.saturating_add(self.length).saturating_less_one()
     }
 }
 

--- a/primitives/avn-common/src/event_discovery.rs
+++ b/primitives/avn-common/src/event_discovery.rs
@@ -26,8 +26,7 @@ impl EthBlockRange {
         }
     }
     pub fn range(&self) -> (u32, u32) {
-        let end_block = self.end_block();
-        (self.start_block, end_block)
+        (self.start_block, self.end_block())
     }
     pub fn end_block(&self) -> u32 {
         self.start_block.saturating_add(self.length).saturating_less_one()

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -24,10 +24,8 @@ use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
     traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto},
     transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult, WeakBoundedVec,
+    ApplyExtrinsicResult,
 };
-
-use pallet_eth_bridge::Author;
 
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -987,6 +985,7 @@ impl_runtime_apis! {
                 None
             }
         }
+
         fn query_has_author_casted_vote(account_id: AccountId) -> bool{
            pallet_eth_bridge::author_has_cast_event_vote::<Runtime>(&account_id) ||
            pallet_eth_bridge::author_has_submitted_latest_block::<Runtime>(&account_id)


### PR DESCRIPTION
## Proposed changes

- Fixes an issue where the last block of a range was polled twice and included to the next range as well.
- Addresses feature PR feedback
- cleanup