### PR TITLE
SYS-4125 Fix `try runtime` compilation error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-lower-rpc"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "avn-service",
  "futures",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "avn-node-parachain"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "avn-lower-rpc",
  "avn-parachain-runtime",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "frame-support",
  "hex-literal 0.4.1",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
@@ -6823,7 +6823,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6870,7 +6870,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7160,7 +7160,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -7186,7 +7186,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "env_logger 0.10.0",
  "frame-benchmarking",
@@ -7381,7 +7381,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7508,7 +7508,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7785,7 +7785,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7852,7 +7852,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7960,7 +7960,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -12556,7 +12556,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "5.4.1"
+version = "5.4.2"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -58,7 +58,10 @@ use alloc::{
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::convert::TryInto;
-use frame_support::{dispatch::DispatchResultWithPostInfo, log, traits::IsSubType, BoundedVec};
+use frame_support::{
+    dispatch::DispatchResultWithPostInfo, log, pallet_prelude::StorageVersion, traits::IsSubType,
+    BoundedVec,
+};
 use frame_system::{
     ensure_none, ensure_root,
     offchain::{SendTransactionTypes, SubmitTransaction},
@@ -126,6 +129,8 @@ const PALLET_NAME: &'static [u8] = b"EthBridge";
 const ADD_CONFIRMATION_CONTEXT: &'static [u8] = b"EthBridgeConfirmation";
 const ADD_CORROBORATION_CONTEXT: &'static [u8] = b"EthBridgeCorroboration";
 const ADD_ETH_TX_HASH_CONTEXT: &'static [u8] = b"EthBridgeEthTxHash";
+
+const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -200,6 +205,7 @@ pub mod pallet {
     }
 
     #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
     pub struct Pallet<T>(_);
 
     #[pallet::storage]

--- a/pallets/token-manager/src/migration.rs
+++ b/pallets/token-manager/src/migration.rs
@@ -10,6 +10,9 @@ use frame_system::pallet_prelude::BlockNumberFor;
 #[cfg(feature = "try-runtime")]
 use crate::Vec;
 
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 pub fn set_lower_schedule_period<T: Config>() -> Weight {
@@ -54,14 +57,14 @@ impl<T: Config> OnRuntimeUpgrade for SetLowerSchedulePeriod<T> {
     }
 
     #[cfg(feature = "try-runtime")]
-    fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+    fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
         use codec::Encode;
 
         Ok(<LowerSchedulePeriod<T>>::get().encode())
     }
 
     #[cfg(feature = "try-runtime")]
-    fn post_upgrade(input: Vec<u8>) -> Result<(), &'static str> {
+    fn post_upgrade(input: Vec<u8>) -> Result<(), TryRuntimeError> {
         use codec::Decode;
         use sp_runtime::traits::Zero;
 

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -947,8 +947,8 @@ impl_runtime_apis! {
 
     #[cfg(feature = "try-runtime")]
     impl frame_try_runtime::TryRuntime<Block> for Runtime {
-        fn on_runtime_upgrade(checks: bool) -> (Weight, Weight) {
-            log::info!("try-runtime::on_runtime_upgrade avn-parachain.");
+        fn on_runtime_upgrade(checks: frame_try_runtime::UpgradeCheckSelect) -> (Weight, Weight) {
+            log::info!("try-runtime::on_runtime_upgrade avn-test-parachain.");
             let weight = Executive::try_runtime_upgrade(checks).unwrap();
             (weight, RuntimeBlockWeights::get().max_block)
         }


### PR DESCRIPTION
## Proposed changes

This PR fixes the compilation error thrown when compiling the node with the `try-runtime` feature.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [x] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [x] Documentation updated
- [x] Business logic tested successfully
- [x] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.