### PR TITLE
feat: Enhance avn-service configuration and logging

### DIFF
--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -376,7 +376,7 @@ where
 
     let events_registry = EventRegistry::new();
 
-    log::info!("⛓️  ETH EVENT HANDLER INITIALIZED");
+    log::info!("⛓️  Ethereum events handler service initialised.");
 
     let current_node_author;
     loop {

--- a/node/avn-service/src/keystore_utils.rs
+++ b/node/avn-service/src/keystore_utils.rs
@@ -20,6 +20,13 @@ pub fn get_eth_address_bytes_from_keystore(keystore_path: &PathBuf) -> Result<Ve
         Err(server_error(format!("No keys found in the keystore for {:?}", ETHEREUM_SIGNING_KEY)))?
     }
 
+    if addresses.len() > 1 {
+        Err(server_error(format!(
+            "Multiple keys found in the keystore for {:?}. Only one should be present.",
+            ETHEREUM_SIGNING_KEY
+        )))?
+    }
+
     return Ok(addresses[0].clone())
 }
 

--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -417,7 +417,7 @@ impl<T: Config> Pallet<T> {
     ) -> bool {
         // verify that the incoming (unverified) pubkey is actually a validator
         if !Self::is_validator(&validator.account_id) {
-            log::warn!("✋ Account: {:?} is not a authority.", &validator.account_id);
+            log::warn!("✋ Account: {:?} is not an authority.", &validator.account_id);
             return false
         }
         let recovered_public_key = recover_public_key_from_ecdsa_signature(signature, &data);

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -181,7 +181,7 @@ pub fn hash_with_ethereum_prefix(hex_message: &String) -> Result<[u8; 32], ECDSA
     prefixed_message.append(&mut message_bytes.to_vec());
     let hash = keccak_256(&prefixed_message);
     log::debug!(
-        "🪲 Request to sign data: {:?},\n data with ethereum prefix: {:?}, \n result hash: {:?}",
+        "🪲 Data without prefix: {:?},\n data with ethereum prefix: {:?}, \n result hash: {:?}",
         &hex_message,
         &prefixed_message,
         hex::encode(&hash),

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -159,11 +159,11 @@ pub fn safe_sub_block_numbers<BlockNumber: Member + Codec + AtLeast32Bit>(
 }
 
 pub fn recover_public_key_from_ecdsa_signature(
-    signature: ecdsa::Signature,
-    message: String,
+    signature: &ecdsa::Signature,
+    message: &String,
 ) -> Result<ecdsa::Public, ECDSAVerificationError> {
     match secp256k1_ecdsa_recover_compressed(
-        &signature.into(),
+        signature.as_ref(),
         &hash_with_ethereum_prefix(message)?,
     ) {
         Ok(pubkey) => return Ok(ecdsa::Public::from_raw(pubkey)),
@@ -173,13 +173,20 @@ pub fn recover_public_key_from_ecdsa_signature(
     }
 }
 
-pub fn hash_with_ethereum_prefix(hex_message: String) -> Result<[u8; 32], ECDSAVerificationError> {
+pub fn hash_with_ethereum_prefix(hex_message: &String) -> Result<[u8; 32], ECDSAVerificationError> {
     let message_bytes = hex::decode(hex_message.trim_start_matches("0x"))
         .map_err(|_| ECDSAVerificationError::InvalidMessageFormat)?;
 
     let mut prefixed_message = ETHEREUM_PREFIX.to_vec();
     prefixed_message.append(&mut message_bytes.to_vec());
-    Ok(keccak_256(&prefixed_message))
+    let hash = keccak_256(&prefixed_message);
+    log::debug!(
+        "🪲 Request to sign data: {:?},\n data with ethereum prefix: {:?}, \n result hash: {:?}",
+        &hex_message,
+        &prefixed_message,
+        hex::encode(&hash),
+    );
+    Ok(hash)
 }
 
 pub fn verify_signature<Signature: Member + Verify + TypeInfo, AccountId: Member>(


### PR DESCRIPTION
## Proposed changes

Improves avn-service checks to ensure signing operations are only performed when the node is correctly configured with a single Ethereum key in the keystore.

Additionally, enhances logging around signing operations for better visibility and eliminates multiple implementations of the ethereum hashing function.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
