### PR TITLE
feat: Upgrade node to polkadot-sdk 1.6 - WIP

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,14 +16,15 @@ name = "avn-parachain-collator"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.4.2", features = ["derive"] }
+clap = { version = "4.4.14", features = ["derive"] }
 log = "0.4.20"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-serde = { version = "1.0.163", features = ["derive"] }
+serde = { version = "1.0.195", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 hex-literal = "0.4.1"
 hex = "0.4"
-serde_json = "1.0.85"
+serde_json = { version = "1.0.111", features = ["arbitrary_precision"] }
+
 futures = "0.3.21"
 cfg-if = "0.1"
 
@@ -111,6 +112,7 @@ substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-s
 [features]
 default = ["avn-native-runtime"]
 runtime-benchmarks = [
+    "cumulus-primitives-core/runtime-benchmarks",
     "frame-benchmarking-cli/runtime-benchmarks",
     "frame-benchmarking/runtime-benchmarks",
     "polkadot-cli/runtime-benchmarks",

--- a/node/avn-lower-rpc/Cargo.toml
+++ b/node/avn-lower-rpc/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.21"
 log = "0.4.20"
 parking_lot = "0.12.1"
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.163", features = ["derive"], default-features = false}
+serde = { version = "1.0.195", features = ["derive"], default-features = false}
 serde_json = "1.0.85"
 thiserror = "1.0"
 hex = "0.4"

--- a/node/avn-service/Cargo.toml
+++ b/node/avn-service/Cargo.toml
@@ -29,7 +29,8 @@ jsonrpc-core = "18.0.0"
 tokio = { version = "1.19", features = ["sync"] }
 
 hex = "0.4"
-secp256k1 = { version = "0.24.0", default-features = false, features = [
+# Ensure compatibility by matching sp-core's secp256k1 version. Let cargo handle exact version matching.
+secp256k1 = { version = ">0.26.0", default-features = false, features = [
     "recovery",
     "alloc",
 ] }

--- a/node/avn-service/src/lib.rs
+++ b/node/avn-service/src/lib.rs
@@ -436,7 +436,7 @@ where
             let my_priv_key = get_priv_key(keystore_path, &my_eth_address)?;
 
             let secret = SecretKey::from_slice(&my_priv_key)?;
-            let message = secp256k1::Message::from_slice(&hashed_message)?;
+            let message = secp256k1::Message::from_digest_slice(&hashed_message)?;
             let signature: Signature = secp.sign_ecdsa_recoverable(&message, &secret).into();
 
             Ok(hex::encode(signature.encode()))

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -162,7 +162,7 @@ impl Extensions {
 }
 
 /// Sets currency to AVT for an AvN chain
-pub(crate) fn avn_chain_properties() -> Option<sc_chain_spec::Properties> {
+pub(crate) fn avn_chain_properties() -> sc_chain_spec::Properties {
     // Give your base currency a unit name and decimal places
     let mut properties = sc_chain_spec::Properties::new();
     properties.insert("tokenSymbol".into(), "AVT".into());
@@ -170,5 +170,5 @@ pub(crate) fn avn_chain_properties() -> Option<sc_chain_spec::Properties> {
     properties.insert("ss58Format".into(), 42.into());
     // TODO: Replace with this when we switch to using custom prefixes
     // properties.insert("ss58Format".into(), 65.into());
-    return Some(properties)
+    return properties
 }

--- a/node/src/chain_spec/stable/local.rs
+++ b/node/src/chain_spec/stable/local.rs
@@ -11,151 +11,135 @@ use sp_core::{ecdsa, sr25519, ByteArray, H160};
 
 pub fn development_config() -> ChainSpec {
     let dev_rococo_parachain_id: u32 = 2060;
-    ChainSpec::from_genesis(
-        // Name
-        "AvN Local Development Parachain",
-        // ID
-        "dev",
-        ChainType::Development,
-        move || {
-            testnet_genesis(
-                // initial collators.
-                vec![
-                    get_authority_keys_from_seed("Alice//stash"),
-                    get_authority_keys_from_seed("Ferdie"),
-                ],
-                vec![
-                    (get_account_id_from_seed::<sr25519::Public>("Alice"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Bob"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Charlie"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Dave"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Eve"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Ferdie"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Alice//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Bob//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Charlie//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Dave//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Eve//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Bank"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("gateway-relayer"), AVT_ENDOWMENT),
-                    // Use in avn-proxy benchmarks
-                    (get_account_id_from_seed_no_derivation::<sr25519::Public>("kiss mule sheriff twice make bike twice improve rate quote draw enough"), AVT_ENDOWMENT),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("nft-marketplace-relayer"),
-                        AVT_ENDOWMENT,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("onboarding-relayer"),
-                        AVT_ENDOWMENT,
-                    ),
-                    (get_account_id_from_seed::<sr25519::Public>("test-account"), AVT_ENDOWMENT),
-                ],
-                dev_rococo_parachain_id.into(),
-                // SUDO account
-                get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-                // AVT contract
-                H160(hex!("93ba86eCfDDD9CaAAc29bE83aCE5A3188aC47730")),
-                // AVN contract
-                H160(hex!("9d6394ea67D297b4Fc777f719F82Ae1F1fc06383")),
-                vec![],
-                dev_ethereum_public_keys(),
-                vec![],
-                SMALL_EVENT_CHALLENGE_PERIOD,
-                HALF_HOUR_SCHEDULE_PERIOD,
-                SMALL_VOTING_PERIOD,
-                // Non AVT token address
-                Some(H160(hex!("ea5da4fd16cc61ffc4235874d6ff05216e3e038e"))),
-            )
-        },
-        Vec::new(),
-        None,
-        Some("avn-dev"),
-        None,
-        avn_chain_properties(),
+    let properties = avn_chain_properties();
+
+    ChainSpec::builder(
+        avn_parachain_runtime::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
+            relay_chain: "rococo-local".into(),
+            // You MUST set this to the correct network!
             para_id: dev_rococo_parachain_id,
         },
     )
+    .with_name("Development")
+    .with_protocol_id("template-dev")
+    .with_id("dev")
+    .with_properties(properties)
+    .with_chain_type(ChainType::Development)
+    .with_genesis_config_patch(testnet_genesis(
+        // initial collators.
+        vec![get_authority_keys_from_seed("Alice//stash"), get_authority_keys_from_seed("Ferdie")],
+        vec![
+            (get_account_id_from_seed::<sr25519::Public>("Alice"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Bob"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Charlie"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Dave"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Eve"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Ferdie"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Alice//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Bob//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Charlie//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Dave//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Eve//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Bank"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("gateway-relayer"), AVT_ENDOWMENT),
+            // Use in avn-proxy benchmarks
+            (
+                get_account_id_from_seed_no_derivation::<sr25519::Public>(
+                    "kiss mule sheriff twice make bike twice improve rate quote draw enough",
+                ),
+                AVT_ENDOWMENT,
+            ),
+            (get_account_id_from_seed::<sr25519::Public>("nft-marketplace-relayer"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("onboarding-relayer"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("test-account"), AVT_ENDOWMENT),
+        ],
+        dev_rococo_parachain_id.into(),
+        // SUDO account
+        get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+        // AVT contract
+        H160(hex!("93ba86eCfDDD9CaAAc29bE83aCE5A3188aC47730")),
+        // AVN contract
+        H160(hex!("9d6394ea67D297b4Fc777f719F82Ae1F1fc06383")),
+        vec![],
+        dev_ethereum_public_keys(),
+        vec![],
+        SMALL_EVENT_CHALLENGE_PERIOD,
+        HALF_HOUR_SCHEDULE_PERIOD,
+        SMALL_VOTING_PERIOD,
+        // Non AVT token address
+        Some(H160(hex!("ea5da4fd16cc61ffc4235874d6ff05216e3e038e"))),
+    ))
+    .build()
 }
 
 pub fn local_testnet_config() -> ChainSpec {
-    ChainSpec::from_genesis(
-        // Name
-        "AvN Local Parachain",
-        // ID
-        "local_testnet",
-        ChainType::Local,
-        move || {
-            testnet_genesis(
-                // initial collators.
-                vec![
-                    get_authority_keys_from_seed("Eve"),
-                    get_authority_keys_from_seed("Ferdie"),
-                    get_authority_keys_from_seed("Dave"),
-                    get_authority_keys_from_seed("Charlie"),
-                ],
-                vec![
-                    (get_account_id_from_seed::<sr25519::Public>("Alice"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Bob"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Charlie"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Dave"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Eve"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Ferdie"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Alice//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Bob//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Charlie//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Dave//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Eve//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Bank"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("gateway-relayer"), AVT_ENDOWMENT),
-                    // Use in avn-proxy benchmarks
-                    (get_account_id_from_seed_no_derivation::<sr25519::Public>("kiss mule sheriff twice make bike twice improve rate quote draw enough"), AVT_ENDOWMENT),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("nft-marketplace-relayer"),
-                        AVT_ENDOWMENT,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("onboarding-relayer"),
-                        AVT_ENDOWMENT,
-                    ),
-                    (get_account_id_from_seed::<sr25519::Public>("test-account"), AVT_ENDOWMENT),
-                ],
-                2000.into(),
-                // SUDO account
-                get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-                // AVT contract
-                H160(hex!("93ba86eCfDDD9CaAAc29bE83aCE5A3188aC47730")),
-                // AVN contract
-                H160(hex!("9d6394ea67D297b4Fc777f719F82Ae1F1fc06383")),
-                vec![],
-                dev_ethereum_public_keys(),
-                vec![],
-                SMALL_EVENT_CHALLENGE_PERIOD,
-                HALF_HOUR_SCHEDULE_PERIOD,
-                SMALL_VOTING_PERIOD,
-                // Non AVT token address
-                Some(H160(hex!("ea5da4fd16cc61ffc4235874d6ff05216e3e038e"))),
-            )
-        },
-        // Bootnodes
-        Vec::new(),
-        // Telemetry
-        None,
-        // Protocol ID
-        Some("avn-local"),
-        // Fork ID
-        None,
-        // Properties
-        avn_chain_properties(),
-        // Extensions
+    let properties = avn_chain_properties();
+    ChainSpec::builder(
+        avn_parachain_runtime::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
+            relay_chain: "rococo-local".into(),
+            // You MUST set this to the correct network!
             para_id: 2000,
         },
     )
+    .with_name("AvN Local Parachain")
+    .with_protocol_id("avn-local")
+    .with_id("local-testnet")
+    .with_properties(properties)
+    .with_chain_type(ChainType::Local)
+    .with_genesis_config_patch(testnet_genesis(
+        // initial collators.
+        vec![
+            get_authority_keys_from_seed("Eve"),
+            get_authority_keys_from_seed("Ferdie"),
+            get_authority_keys_from_seed("Dave"),
+            get_authority_keys_from_seed("Charlie"),
+        ],
+        vec![
+            (get_account_id_from_seed::<sr25519::Public>("Alice"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Bob"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Charlie"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Dave"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Eve"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Ferdie"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Alice//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Bob//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Charlie//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Dave//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Eve//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Bank"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("gateway-relayer"), AVT_ENDOWMENT),
+            // Use in avn-proxy benchmarks
+            (
+                get_account_id_from_seed_no_derivation::<sr25519::Public>(
+                    "kiss mule sheriff twice make bike twice improve rate quote draw enough",
+                ),
+                AVT_ENDOWMENT,
+            ),
+            (get_account_id_from_seed::<sr25519::Public>("nft-marketplace-relayer"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("onboarding-relayer"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("test-account"), AVT_ENDOWMENT),
+        ],
+        2000.into(),
+        // SUDO account
+        get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+        // AVT contract
+        H160(hex!("93ba86eCfDDD9CaAAc29bE83aCE5A3188aC47730")),
+        // AVN contract
+        H160(hex!("9d6394ea67D297b4Fc777f719F82Ae1F1fc06383")),
+        vec![],
+        dev_ethereum_public_keys(),
+        vec![],
+        SMALL_EVENT_CHALLENGE_PERIOD,
+        HALF_HOUR_SCHEDULE_PERIOD,
+        SMALL_VOTING_PERIOD,
+        // Non AVT token address
+        Some(H160(hex!("ea5da4fd16cc61ffc4235874d6ff05216e3e038e"))),
+    ))
+    .build()
 }
 
 fn dev_ethereum_public_keys() -> Vec<EthPublicKey> {

--- a/node/src/chain_spec/stable/staging.rs
+++ b/node/src/chain_spec/stable/staging.rs
@@ -12,76 +12,64 @@ use sp_core::{crypto::UncheckedInto, ecdsa, sr25519, ByteArray, H160};
 
 pub fn staging_testnet_config() -> ChainSpec {
     let staging_parachain_id: u32 = 3000;
-    ChainSpec::from_genesis(
-        // Name
-        "AvN Staging Parachain",
-        // ID
-        "avn_staging_testnet",
-        ChainType::Live,
-        move || {
-            testnet_genesis(
-                // initial collators.
-                vec![
-                    get_authority_keys_from_seed_with_derivation("avn-collator-1"),
-                    get_authority_keys_from_seed_with_derivation("avn-collator-2"),
-                    get_authority_keys_from_seed_with_derivation("avn-collator-3"),
-                    get_authority_keys_from_seed_with_derivation("avn-collator-4"),
-                ],
-                // endowed accounts
-                vec![
-                    (get_account_id_from_seed::<sr25519::Public>("avn-collator-1"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("avn-collator-2"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("avn-collator-3"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("avn-collator-4"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("avn-sudo"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("Bank"), AVT_ENDOWMENT),
-                    (get_account_id_from_seed::<sr25519::Public>("gateway-relayer"), AVT_ENDOWMENT),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("nft-marketplace-relayer"),
-                        AVT_ENDOWMENT,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("onboarding-relayer"),
-                        AVT_ENDOWMENT,
-                    ),
-                    (get_account_id_from_seed::<sr25519::Public>("test-account"), AVT_ENDOWMENT),
-                ],
-                staging_parachain_id.into(),
-                // SUDO account
-                get_account_id_from_seed::<sr25519::Public>("avn-sudo"),
-                // AVT contract
-                H160(hex!("b3594297e1F257AD2A90222F66393645C6622263")),
-                // AVN contract
-                H160(hex!("2bb59e4f9Cd053779E5d6f6dB2724F5DF5e53ce6")),
-                vec![],
-                staging_ethereum_public_keys(),
-                vec![],
-                SMALL_EVENT_CHALLENGE_PERIOD,
-                HALF_HOUR_SCHEDULE_PERIOD,
-                SMALL_VOTING_PERIOD,
-                None,
-            )
-        },
-        // Bootnodes
-        Vec::new(),
-        // Telemetry
-        None,
-        // Protocol ID
-        Some("staging-parachain"),
-        // Fork ID
-        None,
-        // Properties
-        avn_chain_properties(),
-        // Extensions
+    let properties = avn_chain_properties();
+
+    ChainSpec::builder(
+        avn_parachain_runtime::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
+            relay_chain: "rococo-local".into(),
+            // You MUST set this to the correct network!
             para_id: staging_parachain_id,
         },
     )
+    .with_name("AvN Staging Parachain")
+    .with_protocol_id("avn-staging-testnet")
+    .with_id("staging-parachain")
+    .with_properties(properties)
+    .with_chain_type(ChainType::Live)
+    .with_genesis_config_patch(testnet_genesis(
+        // initial collators.
+        vec![
+            get_authority_keys_from_seed_with_derivation("avn-collator-1"),
+            get_authority_keys_from_seed_with_derivation("avn-collator-2"),
+            get_authority_keys_from_seed_with_derivation("avn-collator-3"),
+            get_authority_keys_from_seed_with_derivation("avn-collator-4"),
+        ],
+        // endowed accounts
+        vec![
+            (get_account_id_from_seed::<sr25519::Public>("avn-collator-1"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("avn-collator-2"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("avn-collator-3"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("avn-collator-4"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("avn-sudo"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("Bank"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("gateway-relayer"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("nft-marketplace-relayer"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("onboarding-relayer"), AVT_ENDOWMENT),
+            (get_account_id_from_seed::<sr25519::Public>("test-account"), AVT_ENDOWMENT),
+        ],
+        staging_parachain_id.into(),
+        // SUDO account
+        get_account_id_from_seed::<sr25519::Public>("avn-sudo"),
+        // AVT contract
+        H160(hex!("b3594297e1F257AD2A90222F66393645C6622263")),
+        // AVN contract
+        H160(hex!("2bb59e4f9Cd053779E5d6f6dB2724F5DF5e53ce6")),
+        vec![],
+        staging_ethereum_public_keys(),
+        vec![],
+        SMALL_EVENT_CHALLENGE_PERIOD,
+        HALF_HOUR_SCHEDULE_PERIOD,
+        SMALL_VOTING_PERIOD,
+        None,
+    ))
+    .build()
 }
 
 pub fn staging_dev_testnet_config() -> ChainSpec {
     let staging_parachain_id: u32 = 2000;
+    let properties = avn_chain_properties();
+
     let mut endowed_accounts = vec![
         // SUDO account
         (
@@ -93,51 +81,41 @@ pub fn staging_dev_testnet_config() -> ChainSpec {
     ];
     endowed_accounts.append(&mut staging_dev_endowed_collators());
 
-    ChainSpec::from_genesis(
-        // Name
-        "AvN Staging Dev Parachain",
-        // ID
-        "avn_staging_dev_testnet",
-        ChainType::Live,
-        move || {
-            testnet_genesis(
-                // initial collators.
-                staging_uat_authorities_keys(),
-                // endowed accounts
-                endowed_accounts.clone(),
-                staging_parachain_id.into(),
-                // SUDO account
-                hex!["20ef357ca657d8cce8fcfc2e230871347fc68b1451a575eaedb9797616101608"].into(),
-                // AVT contract
-                H160(hex!("93ba86eCfDDD9CaAAc29bE83aCE5A3188aC47730")),
-                // AVN contract
-                H160(hex!("0Dd31348e68b6400bf8BdE84a1AaF733D9fCBf9B")),
-                // TODO update this if needed with the nft contracts
-                vec![],
-                staging_dev_ethereum_public_keys(),
-                vec![],
-                NORMAL_EVENT_CHALLENGE_PERIOD,
-                FOUR_HOURS_SCHEDULE_PERIOD,
-                NORMAL_VOTING_PERIOD,
-                None,
-            )
-        },
-        // Bootnodes
-        Vec::new(),
-        // Telemetry
-        None,
-        // Protocol ID
-        Some("staging-dev"),
-        // Fork ID
-        None,
-        // Properties
-        avn_chain_properties(),
-        // Extensions
+    ChainSpec::builder(
+        avn_parachain_runtime::WASM_BINARY.expect("WASM binary was not built, please build it!"),
         Extensions {
-            relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
+            relay_chain: "rococo-local".into(),
+            // You MUST set this to the correct network!
             para_id: staging_parachain_id,
         },
     )
+    .with_name("AvN Staging Dev Parachain")
+    .with_protocol_id("staging-dev")
+    .with_id("avn_staging_dev_testnet")
+    .with_properties(properties)
+    .with_chain_type(ChainType::Live)
+    .with_genesis_config_patch(testnet_genesis(
+        // initial collators.
+        staging_uat_authorities_keys(),
+        // endowed accounts
+        endowed_accounts.clone(),
+        staging_parachain_id.into(),
+        // SUDO account
+        hex!["20ef357ca657d8cce8fcfc2e230871347fc68b1451a575eaedb9797616101608"].into(),
+        // AVT contract
+        H160(hex!("93ba86eCfDDD9CaAAc29bE83aCE5A3188aC47730")),
+        // AVN contract
+        H160(hex!("0Dd31348e68b6400bf8BdE84a1AaF733D9fCBf9B")),
+        // TODO update this if needed with the nft contracts
+        vec![],
+        staging_dev_ethereum_public_keys(),
+        vec![],
+        NORMAL_EVENT_CHALLENGE_PERIOD,
+        FOUR_HOURS_SCHEDULE_PERIOD,
+        NORMAL_VOTING_PERIOD,
+        None,
+    ))
+    .build()
 }
 
 #[rustfmt::skip]

--- a/node/src/chain_spec/test/mod.rs
+++ b/node/src/chain_spec/test/mod.rs
@@ -20,7 +20,8 @@ use sp_core::{H160, H256};
 use hex_literal::hex;
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
-pub type ChainSpec = sc_service::GenericChainSpec<avn_test_runtime::GenesisConfig, Extensions>;
+// TODO remove this
+pub type ChainSpec = sc_service::GenericChainSpec<(), Extensions>;
 
 /// Generate the session keys from individual elements.
 ///

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -28,8 +28,11 @@ pub enum Subcommand {
     /// Remove the whole chain.
     PurgeChain(cumulus_client_cli::PurgeChainCmd),
 
-    /// Export the genesis state of the parachain.
-    ExportGenesisState(cumulus_client_cli::ExportGenesisStateCommand),
+    /// Export the genesis head data of the parachain.
+    ///
+    /// Head data is the encoded block header.
+    #[command(alias = "export-genesis-state")]
+    ExportGenesisHead(cumulus_client_cli::ExportGenesisHeadCommand),
 
     /// Export the genesis wasm of the parachain.
     ExportGenesisWasm(cumulus_client_cli::ExportGenesisWasmCommand),

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -167,12 +167,12 @@ pub fn run() -> Result<()> {
                 cmd.run(config, polkadot_config)
             })
         },
-        Some(Subcommand::ExportGenesisState(cmd)) => {
+        Some(Subcommand::ExportGenesisHead(cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.sync_run(|config| {
                 let partials = new_partial::<RuntimeApi>(&config)?;
 
-                cmd.run(&*config.chain_spec, &*partials.client)
+                cmd.run(partials.client)
             })
         },
         Some(Subcommand::ExportGenesisWasm(cmd)) => {


### PR DESCRIPTION
## Proposed changes

- Updated chainspec generation to use a JSON object for genesis state creation, serialized with `serde-json` (adds `arbitrary_precision` feature for u128 serialization due to ERC20 denominations).
- Updated `avn-service` dependencies and switched to `sp-core`'s secp256k1.
- Various interface and compilation fixes.

TODO:
[ ] Test runtime chainspec generation.
[ ] Refactor chainspec generation to DRY the `testnet_genesis` function. [ ] Decision on required `serde-json` features.

