### PR TITLE
feat: Upgrade node to polkadot-sdk 1.6 - pallet avn mocks

### DIFF
--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -97,9 +97,10 @@ pub mod pallet {
         AvnBridgeContractUpdated { old_contract: H160, new_contract: H160 },
     }
 
-    #[pallet::config]
+    #[pallet::config(with_default)]
     pub trait Config: frame_system::Config {
         /// Overarching event type
+        #[pallet::no_default_bounds]
         type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// The identifier type for an authority.
@@ -117,6 +118,28 @@ pub mod pallet {
         type DisabledValidatorChecker: DisabledValidatorChecker<Self::AccountId>;
 
         type WeightInfo: WeightInfo;
+    }
+
+    /// Default implementations of [`DefaultConfig`], which can be used to implement [`Config`].
+    pub mod config_preludes {
+        use super::*;
+        use frame_support::derive_impl;
+        use sp_runtime::testing::UintAuthorityId;
+        pub struct TestDefaultConfig;
+
+        #[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig, no_aggregated_types)]
+        impl frame_system::DefaultConfig for TestDefaultConfig {}
+
+        #[frame_support::register_default_impl(TestDefaultConfig)]
+        impl DefaultConfig for TestDefaultConfig {
+            #[inject_runtime_type]
+            type RuntimeEvent = ();
+            type AuthorityId = UintAuthorityId;
+            type EthereumPublicKeyChecker = ();
+            type NewSessionHandler = ();
+            type DisabledValidatorChecker = ();
+            type WeightInfo = ();
+        }
     }
 
     #[pallet::pallet]

--- a/pallets/avn/src/mock.rs
+++ b/pallets/avn/src/mock.rs
@@ -3,8 +3,8 @@
 #![cfg(test)]
 
 use crate::{self as pallet_avn, *};
-use frame_support::{parameter_types, weights::Weight};
-use frame_system as system;
+use frame_support::{derive_impl, parameter_types, weights::Weight};
+use frame_system::{self as system, DefaultConfig};
 use hex_literal::hex;
 use pallet_session as session;
 use sp_core::{
@@ -50,30 +50,15 @@ parameter_types! {
     pub const ChallengePeriod: u64 = 2;
 }
 
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl system::Config for TestRuntime {
-    type BaseCallFilter = frame_support::traits::Everything;
-    type BlockWeights = ();
-    type BlockLength = ();
-    type DbWeight = ();
     type RuntimeOrigin = RuntimeOrigin;
     type Nonce = u64;
     type RuntimeCall = RuntimeCall;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type AccountId = u64;
-    type Lookup = IdentityLookup<Self::AccountId>;
     type Block = Block;
     type RuntimeEvent = RuntimeEvent;
     type BlockHashCount = BlockHashCount;
-    type Version = ();
     type PalletInfo = PalletInfo;
-    type AccountData = ();
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type SystemWeightInfo = ();
-    type SS58Prefix = ();
-    type OnSetCode = ();
-    type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 parameter_types! {

--- a/pallets/avn/src/mock.rs
+++ b/pallets/avn/src/mock.rs
@@ -3,12 +3,12 @@
 #![cfg(test)]
 
 use crate::{self as pallet_avn, *};
-use frame_support::{derive_impl, parameter_types, weights::Weight};
+use frame_support::{derive_impl, parameter_types};
 use frame_system::{self as system, DefaultConfig};
 use hex_literal::hex;
 use pallet_session as session;
 use sp_core::offchain::testing::{OffchainState, PendingRequest};
-use sp_runtime::{testing::UintAuthorityId, traits::ConvertInto, BuildStorage, Perbill};
+use sp_runtime::{testing::UintAuthorityId, traits::ConvertInto, BuildStorage};
 use sp_state_machine::BasicExternalities;
 use std::cell::RefCell;
 
@@ -16,6 +16,10 @@ pub type AccountId = <TestRuntime as system::Config>::AccountId;
 pub type AVN = Pallet<TestRuntime>;
 
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
+
+pub(crate) type SessionIndex = u32;
+pub(crate) static CUSTOM_BRIDGE_CONTRACT: H160 =
+    H160(hex!("11111AAAAA22222BBBBB11111AAAAA22222BBBBB"));
 
 frame_support::construct_runtime!(
     pub enum TestRuntime
@@ -29,47 +33,15 @@ frame_support::construct_runtime!(
 #[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
 impl Config for TestRuntime {}
 
-parameter_types! {
-    pub const BlockHashCount: u64 = 250;
-    pub const MaximumBlockWeight: Weight = Weight::from_parts(1024 as u64, 0);
-    pub const MaximumBlockLength: u32 = 2 * 1024;
-    pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
-    pub const ChallengePeriod: u64 = 2;
-}
-
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl system::Config for TestRuntime {
-    type RuntimeOrigin = RuntimeOrigin;
     type Nonce = u64;
-    type RuntimeCall = RuntimeCall;
     type Block = Block;
-    type RuntimeEvent = RuntimeEvent;
-    type BlockHashCount = BlockHashCount;
-    type PalletInfo = PalletInfo;
 }
 
 parameter_types! {
     pub const Period: u64 = 1;
     pub const Offset: u64 = 0;
-    pub const DisabledValidatorsThreshold: Perbill = Perbill::from_percent(33);
-}
-
-thread_local! {
-    // validator accounts (aka public addresses, public keys-ish)
-    pub static VALIDATORS: RefCell<Option<Vec<u64>>> = RefCell::new(Some(vec![1, 2, 3]));
-}
-
-pub type SessionIndex = u32;
-
-pub static CUSTOM_BRIDGE_CONTRACT: H160 = H160(hex!("11111AAAAA22222BBBBB11111AAAAA22222BBBBB"));
-
-pub struct TestSessionManager;
-impl session::SessionManager<u64> for TestSessionManager {
-    fn new_session(_new_index: SessionIndex) -> Option<Vec<u64>> {
-        VALIDATORS.with(|l| l.borrow_mut().take())
-    }
-    fn end_session(_: SessionIndex) {}
-    fn start_session(_: SessionIndex) {}
 }
 
 impl session::Config for TestRuntime {
@@ -82,6 +54,21 @@ impl session::Config for TestRuntime {
     type ValidatorIdOf = ConvertInto;
     type NextSessionRotation = session::PeriodicSessions<Period, Offset>;
     type WeightInfo = ();
+}
+
+thread_local! {
+    // validator accounts (aka public addresses, public keys-ish)
+    pub static VALIDATORS: RefCell<Option<Vec<u64>>> = RefCell::new(Some(vec![1, 2, 3]));
+}
+
+pub struct TestSessionManager;
+
+impl session::SessionManager<u64> for TestSessionManager {
+    fn new_session(_new_index: SessionIndex) -> Option<Vec<u64>> {
+        VALIDATORS.with(|l| l.borrow_mut().take())
+    }
+    fn end_session(_: SessionIndex) {}
+    fn start_session(_: SessionIndex) {}
 }
 
 pub struct ExtBuilder {

--- a/pallets/avn/src/mock.rs
+++ b/pallets/avn/src/mock.rs
@@ -7,15 +7,8 @@ use frame_support::{derive_impl, parameter_types, weights::Weight};
 use frame_system::{self as system, DefaultConfig};
 use hex_literal::hex;
 use pallet_session as session;
-use sp_core::{
-    offchain::testing::{OffchainState, PendingRequest},
-    H256,
-};
-use sp_runtime::{
-    testing::UintAuthorityId,
-    traits::{BlakeTwo256, ConvertInto, IdentityLookup},
-    BuildStorage, Perbill,
-};
+use sp_core::offchain::testing::{OffchainState, PendingRequest};
+use sp_runtime::{testing::UintAuthorityId, traits::ConvertInto, BuildStorage, Perbill};
 use sp_state_machine::BasicExternalities;
 use std::cell::RefCell;
 
@@ -33,14 +26,8 @@ frame_support::construct_runtime!(
     }
 );
 
-impl Config for TestRuntime {
-    type RuntimeEvent = RuntimeEvent;
-    type AuthorityId = UintAuthorityId;
-    type EthereumPublicKeyChecker = ();
-    type NewSessionHandler = ();
-    type DisabledValidatorChecker = ();
-    type WeightInfo = ();
-}
+#[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
+impl Config for TestRuntime {}
 
 parameter_types! {
     pub const BlockHashCount: u64 = 250;


### PR DESCRIPTION
## Proposed changes
Refactors mock of avn pallet:
- Introduces `TestDefaultConfig` for avn pallet to reduce mocks boilerplate code.
- uses `TestDefaultConfig` for avn pallet tests mocks for `frame_system` and `pallet_avn`