### PR TITLE
Sys 4274/4275 extract smart contract names to an enum and fix return type of latest_finalised_ethereum_block

### DIFF
--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -772,7 +772,7 @@ pub trait BridgeInterface {
         params: &[(Vec<u8>, Vec<u8>)],
         eth_block: Option<u32>,
     ) -> Result<Vec<u8>, DispatchError>;
-    fn latest_finalised_ethereum_block() -> Option<u32>;
+    fn latest_finalised_ethereum_block() -> Result<u32, DispatchError>;
 }
 
 pub trait BridgeInterfaceNotification {

--- a/pallets/eth-bridge/src/tests/lower_proof_tests.rs
+++ b/pallets/eth-bridge/src/tests/lower_proof_tests.rs
@@ -307,7 +307,7 @@ mod lower_proofs {
 
             // Queue a send tx request
             let tx_id = add_new_send_request::<TestRuntime>(
-                &b"removeAuthor".to_vec(),
+                &BridgeContractMethod::RemoveAuthor.as_bytes().to_vec(),
                 &context.request_params,
                 &vec![],
             )

--- a/pallets/eth-bridge/src/tests/lower_proof_tests.rs
+++ b/pallets/eth-bridge/src/tests/lower_proof_tests.rs
@@ -10,6 +10,7 @@ use codec::{alloc::sync::Arc, Decode, Encode};
 use frame_support::traits::Hooks;
 use pallet_avn::{LowerParams, PACKED_LOWER_PARAM_SIZE};
 use parking_lot::RwLock;
+use sp_avn_common::BridgeContractMethod;
 use sp_core::{
     ecdsa,
     offchain::testing::{OffchainState, PendingRequest, PoolState},

--- a/pallets/eth-bridge/src/tests/mock.rs
+++ b/pallets/eth-bridge/src/tests/mock.rs
@@ -8,7 +8,10 @@ use frame_system as system;
 use pallet_avn::{testing::U64To32BytesConverter, EthereumPublicKeyChecker};
 use pallet_session as session;
 use parking_lot::RwLock;
-use sp_avn_common::event_types::{EthEvent, EthEventId, LiftedData, ValidEvents};
+use sp_avn_common::{
+    event_types::{EthEvent, EthEventId, LiftedData, ValidEvents},
+    BridgeContractMethod,
+};
 use sp_core::{
     offchain::{
         testing::{OffchainState, PoolState, TestOffchainExt, TestTransactionPoolExt},
@@ -294,7 +297,7 @@ pub fn setup_context() -> Context {
         third_confirming_author: third_confirming_author.clone(),
         fourth_confirming_author: fourth_confirming_author.clone(),
         confirmation_signature,
-        request_function_name: b"publishRoot".to_vec(),
+        request_function_name: BridgeContractMethod::PublishRoot.as_bytes().to_vec(),
         request_params: vec![(b"bytes32".to_vec(), hex::decode(ROOT_HASH).unwrap())],
         lower_params: [1u8; 76],
         finalised_block_vec,

--- a/pallets/eth-bridge/src/tests/tests.rs
+++ b/pallets/eth-bridge/src/tests/tests.rs
@@ -5,6 +5,7 @@ use crate::{eth::generate_send_calldata, mock::*, request::*, *};
 use frame_support::{
     assert_err, assert_noop, assert_ok, dispatch::DispatchResultWithPostInfo, error::BadOrigin,
 };
+use sp_avn_common::BridgeContractMethod;
 use sp_runtime::{testing::UintAuthorityId, DispatchError};
 
 const ROOT_HASH: &str = "30b83f0d722d1d4308ab4660a72dbaf0a7392d5674eca3cd21d57256d42df7a0";

--- a/pallets/eth-bridge/src/tests/tests.rs
+++ b/pallets/eth-bridge/src/tests/tests.rs
@@ -47,7 +47,7 @@ fn corroborate_bad_transactions(
 
 #[test]
 fn check_publish_root_encoding() {
-    let function_name = b"publishRoot".to_vec();
+    let function_name = BridgeContractMethod::PublishRoot.as_bytes().to_vec();
     let params = vec![(b"bytes32".to_vec(), hex::decode(ROOT_HASH).unwrap())];
     let expected_msg_hash = "778a3de5c54e9f2d1c0249cc5c15edf56e205daca24349cc6a71ee0ab04b6300";
     let expected_calldata = "0664c0ba30b83f0d722d1d4308ab4660a72dbaf0a7392d5674eca3cd21d57256d42df7a000000000000000000000000000000000000000000000000000000000651407c9000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000";
@@ -57,7 +57,7 @@ fn check_publish_root_encoding() {
 
 #[test]
 fn check_trigger_growth_encoding() {
-    let function_name = b"triggerGrowth".to_vec();
+    let function_name = BridgeContractMethod::TriggerGrowth.as_bytes().to_vec();
     let params = vec![
         (b"uint128".to_vec(), REWARDS.to_vec()),
         (b"uint128".to_vec(), AVG_STAKED.to_vec()),
@@ -71,7 +71,7 @@ fn check_trigger_growth_encoding() {
 
 #[test]
 fn check_add_author_encoding() {
-    let function_name = b"addAuthor".to_vec();
+    let function_name = BridgeContractMethod::AddAuthor.as_bytes().to_vec();
     let params = vec![
         (b"bytes".to_vec(), hex::decode(T1_PUB_KEY).unwrap()),
         (b"bytes32".to_vec(), hex::decode(T2_PUB_KEY).unwrap()),
@@ -84,7 +84,7 @@ fn check_add_author_encoding() {
 
 #[test]
 fn check_remove_author_encoding() {
-    let function_name = b"removeAuthor".to_vec();
+    let function_name = BridgeContractMethod::RemoveAuthor.as_bytes().to_vec();
     let params = vec![
         (b"bytes32".to_vec(), hex::decode(T2_PUB_KEY).unwrap()),
         (b"bytes".to_vec(), hex::decode(T1_PUB_KEY).unwrap()),
@@ -247,7 +247,7 @@ mod remove_active_request {
         ext.execute_with(|| {
             let context = setup_context();
             let tx_id = add_new_send_request::<TestRuntime>(
-                &b"removeAuthor".to_vec(),
+                &BridgeContractMethod::RemoveAuthor.as_bytes().to_vec(),
                 &context.request_params,
                 &vec![],
             )
@@ -273,7 +273,7 @@ mod remove_active_request {
         ext.execute_with(|| {
             let context = setup_context();
             let _ = add_new_send_request::<TestRuntime>(
-                &b"removeAuthor".to_vec(),
+                &BridgeContractMethod::RemoveAuthor.as_bytes().to_vec(),
                 &context.request_params,
                 &vec![],
             )
@@ -554,7 +554,7 @@ mod add_corroboration {
 fn publish_to_ethereum_creates_new_transaction_request() {
     let mut ext = ExtBuilder::build_default().with_validators().as_externality();
     ext.execute_with(|| {
-            let function_name = b"publishRoot".to_vec();
+            let function_name = BridgeContractMethod::PublishRoot.as_bytes().to_vec();
             let params = vec![(b"bytes32".to_vec(), hex::decode(ROOT_HASH).unwrap())];
 
             let transaction_id = EthBridge::publish(&function_name, &params, vec![]).unwrap();
@@ -565,7 +565,7 @@ fn publish_to_ethereum_creates_new_transaction_request() {
             assert!(System::events().iter().any(|record| matches!(
                 &record.event,
                 mock::RuntimeEvent::EthBridge(crate::Event::PublishToEthereum { function_name, params, tx_id, caller_id: _ })
-                if function_name == &b"publishRoot".to_vec() && tx_id == &transaction_id && params == &vec![(b"bytes32".to_vec(), hex::decode(ROOT_HASH).unwrap())]
+                if function_name == &BridgeContractMethod::PublishRoot.as_bytes().to_vec() && tx_id == &transaction_id && params == &vec![(b"bytes32".to_vec(), hex::decode(ROOT_HASH).unwrap())]
             )));
         });
 }
@@ -579,7 +579,7 @@ fn read_bridge_contract_with_invalid_account_id() {
 
         let result = EthBridge::read_bridge_contract(
             invalid_account_id_encoded,
-            b"referenceRateUpdatedAt",
+            BridgeContractMethod::ReferenceRateUpdatedAt.as_bytes(),
             &vec![],
             None,
         );
@@ -603,7 +603,7 @@ fn publish_fails_with_empty_function_name() {
 fn publish_fails_with_exceeding_params_limit() {
     let mut ext = ExtBuilder::build_default().with_validators().as_externality();
     ext.execute_with(|| {
-        let function_name: &[u8] = b"publishRoot";
+        let function_name: &[u8] = BridgeContractMethod::PublishRoot.as_bytes();
         let params = vec![(b"param1".to_vec(), b"value1".to_vec()); 6]; // ParamsLimit is 5
 
         let result = EthBridge::publish(function_name, &params, vec![]);
@@ -615,7 +615,7 @@ fn publish_fails_with_exceeding_params_limit() {
 fn publish_fails_with_exceeding_type_limit_in_params() {
     let mut ext = ExtBuilder::build_default().with_validators().as_externality();
     ext.execute_with(|| {
-        let function_name: &[u8] = b"publishRoot";
+        let function_name: &[u8] = BridgeContractMethod::PublishRoot.as_bytes();
         let params = vec![(vec![b'a'; 8], b"value1".to_vec())]; // TypeLimit is 7
 
         let result = EthBridge::publish(function_name, &params, vec![]);
@@ -633,7 +633,7 @@ fn publish_and_confirm_transaction() {
     ext.execute_with(|| {
         let context = setup_context();
 
-        let function_name = b"publishRoot".to_vec();
+        let function_name = BridgeContractMethod::PublishRoot.as_bytes().to_vec();
         let params = vec![(b"bytes32".to_vec(), hex::decode(ROOT_HASH).unwrap())];
 
         let tx_id = EthBridge::publish(&function_name, &params, vec![]).unwrap();
@@ -663,7 +663,7 @@ fn publish_and_send_transaction() {
     ext.execute_with(|| {
         let context = setup_context();
 
-        let function_name = b"publishRoot".to_vec();
+        let function_name = BridgeContractMethod::PublishRoot.as_bytes().to_vec();
         let params = vec![(b"bytes32".to_vec(), hex::decode(ROOT_HASH).unwrap())];
 
         let tx_id = EthBridge::publish(&function_name, &params, vec![]).unwrap();
@@ -698,7 +698,7 @@ fn publish_and_corroborate_transaction() {
     ext.execute_with(|| {
         let context = setup_context();
 
-        let function_name = b"publishRoot".to_vec();
+        let function_name = BridgeContractMethod::PublishRoot.as_bytes().to_vec();
         let params = vec![(b"bytes32".to_vec(), hex::decode(ROOT_HASH).unwrap())];
 
         let tx_id = EthBridge::publish(&function_name, &params, vec![]).unwrap();
@@ -734,7 +734,7 @@ fn unsent_transactions_are_replayed() {
     ext.execute_with(|| {
         let context = setup_context();
 
-        let function_name = b"publishRoot".to_vec();
+        let function_name = BridgeContractMethod::PublishRoot.as_bytes().to_vec();
         let params = vec![(b"bytes32".to_vec(), hex::decode(ROOT_HASH).unwrap())];
 
         let tx_id = EthBridge::publish(&function_name, &params, vec![]).unwrap();
@@ -778,7 +778,7 @@ fn self_corroborate_fails() {
     ext.execute_with(|| {
         let context = setup_context();
 
-        let function_name = b"publishRoot".to_vec();
+        let function_name = BridgeContractMethod::PublishRoot.as_bytes().to_vec();
         let params = vec![(b"bytes32".to_vec(), hex::decode(ROOT_HASH).unwrap())];
 
         let tx_id = EthBridge::publish(&function_name, &params, vec![]).unwrap();

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -140,7 +140,7 @@ pub mod pallet {
 
     pub use sp_avn_common::{
         bounds::VotingSessionIdBound, event_types::Validator, safe_add_block_numbers,
-        verify_signature, IngressCounter, Proof,
+        verify_signature, IngressCounter, Proof, BridgeContractMethod
     };
     pub use sp_runtime::{
         traits::{
@@ -2442,7 +2442,7 @@ pub mod pallet {
             )
             .map_err(|_| DispatchError::Other(Error::<T>::ErrorConvertingBalance.into()))?;
 
-            let function_name: &[u8] = b"triggerGrowth";
+            let function_name: &[u8] = BridgeContractMethod::TriggerGrowth.as_bytes();
             let params = vec![
                 (b"uint128".to_vec(), format!("{}", rewards_in_period_128).as_bytes().to_vec()),
                 (

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -140,7 +140,7 @@ pub mod pallet {
 
     pub use sp_avn_common::{
         bounds::VotingSessionIdBound, event_types::Validator, safe_add_block_numbers,
-        verify_signature, IngressCounter, Proof, BridgeContractMethod
+        verify_signature, BridgeContractMethod, IngressCounter, Proof,
     };
     pub use sp_runtime::{
         traits::{

--- a/pallets/summary/src/lib.rs
+++ b/pallets/summary/src/lib.rs
@@ -10,7 +10,7 @@ use sp_avn_common::{
     bounds::VotingSessionIdBound,
     event_types::Validator,
     ocw_lock::{self as OcwLock},
-    safe_add_block_numbers, safe_sub_block_numbers, IngressCounter,
+    safe_add_block_numbers, safe_sub_block_numbers, BridgeContractMethod, IngressCounter,
 };
 use sp_runtime::{
     scale_info::TypeInfo,
@@ -1176,7 +1176,7 @@ pub mod pallet {
             // submitting it to T1, the tier2 session hasn't changed and with it
             // the quorum, making ethereum-transactions reject it
             // In either case, we should not slash anyone.
-            let function_name: &[u8] = b"publishRoot";
+            let function_name: &[u8] = BridgeContractMethod::PublishRoot.as_bytes();
             let params = vec![(b"bytes32".to_vec(), root_data.root_hash.as_fixed_bytes().to_vec())];
             let tx_id = T::BridgeInterface::publish(function_name, &params, Self::pallet_id())
                 .map_err(|e| DispatchError::Other(e.into()))?;

--- a/pallets/summary/src/tests/mock.rs
+++ b/pallets/summary/src/tests/mock.rs
@@ -512,7 +512,7 @@ impl BridgeInterface for TestRuntime {
     }
 
     fn latest_finalised_ethereum_block() -> Result<u32, DispatchError> {
-        None
+        Ok(0)
     }
 }
 

--- a/pallets/summary/src/tests/mock.rs
+++ b/pallets/summary/src/tests/mock.rs
@@ -511,7 +511,7 @@ impl BridgeInterface for TestRuntime {
         Ok(vec![])
     }
 
-    fn latest_finalised_ethereum_block() -> Option<u32> {
+    fn latest_finalised_ethereum_block() -> Result<u32, DispatchError> {
         None
     }
 }

--- a/pallets/summary/src/tests/mock.rs
+++ b/pallets/summary/src/tests/mock.rs
@@ -492,7 +492,7 @@ impl BridgeInterface for TestRuntime {
         _params: &[(Vec<u8>, Vec<u8>)],
         _caller_id: Vec<u8>,
     ) -> Result<u32, DispatchError> {
-        if function_name == b"publishRoot" {
+        if function_name == BridgeContractMethod::PublishRoot.as_bytes() {
             return Ok(INITIAL_TRANSACTION_ID)
         }
         Err(Error::<TestRuntime>::ErrorPublishingSummary.into())

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -35,7 +35,7 @@ use pallet_avn::{
 
 use sp_avn_common::{
     bounds::MaximumValidatorsBound, eth_key_actions::decompress_eth_public_key,
-    event_types::Validator, IngressCounter,
+    event_types::Validator, BridgeContractMethod, IngressCounter,
 };
 use sp_core::{bounded::BoundedVec, ecdsa, H512};
 
@@ -401,7 +401,7 @@ impl<T: Config> Pallet<T> {
             .map_err(|_| Error::<T>::InvalidPublicKey)?;
         let validator_id_bytes =
             <T as pallet::Config>::AccountToBytesConvert::into_bytes(collator_account_id);
-        let function_name = b"addAuthor";
+        let function_name = BridgeContractMethod::AddAuthor.as_bytes();
 
         let params = vec![
             (b"bytes".to_vec(), decompressed_eth_public_key.to_fixed_bytes().to_vec()),
@@ -479,7 +479,7 @@ impl<T: Config> Pallet<T> {
         let validator_id_bytes =
             <T as pallet::Config>::AccountToBytesConvert::into_bytes(validator_id);
 
-        let function_name = b"removeAuthor";
+        let function_name = BridgeContractMethod::RemoveAuthor.as_bytes();
         let params = vec![
             (b"bytes32".to_vec(), validator_id_bytes.to_vec()),
             (b"bytes".to_vec(), decompressed_eth_public_key.to_fixed_bytes().to_vec()),

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -75,7 +75,7 @@ pub enum BridgeContractMethod {
     PublishRoot,
     TriggerGrowth,
     AddAuthor,
-    RawOriginemoveAuthor,
+    RemoveAuthor,
 }
 
 impl BridgeContractMethod {
@@ -86,8 +86,8 @@ impl BridgeContractMethod {
             BridgeContractMethod::UpdateReferenceRate => b"updateReferenceRate",
             BridgeContractMethod::PublishRoot => b"publishRoot",
             BridgeContractMethod::TriggerGrowth => b"TriggerGrowth",
-            BridgeContractMethod::AddAuthor => b"AddAuthor",
-            BridgeContractMethod::RawOriginemoveAuthor => b"RawOriginemoveAuthor",
+            BridgeContractMethod::AddAuthor => b"addAuthor",
+            BridgeContractMethod::RemoveAuthor => b"removeAuthor",
         }
     }
 }

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -68,6 +68,30 @@ pub enum ECDSAVerificationError {
     BadSignature,
 }
 
+pub enum BridgeContractMethod {
+    ReferenceRateUpdatedAt,
+    CheckReferenceRate,
+    UpdateReferenceRate,
+    PublishRoot,
+    TriggerGrowth,
+    AddAuthor,
+    RawOriginemoveAuthor,
+}
+
+impl BridgeContractMethod {
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            BridgeContractMethod::ReferenceRateUpdatedAt => b"referenceRateUpdatedAt",
+            BridgeContractMethod::CheckReferenceRate => b"checkReferenceRate",
+            BridgeContractMethod::UpdateReferenceRate => b"updateReferenceRate",
+            BridgeContractMethod::PublishRoot => b"publishRoot",
+            BridgeContractMethod::TriggerGrowth => b"TriggerGrowth",
+            BridgeContractMethod::AddAuthor => b"AddAuthor",
+            BridgeContractMethod::RawOriginemoveAuthor => b"RawOriginemoveAuthor",
+        }
+    }
+}
+
 // Struct that holds the information about an Ethereum transaction
 // See https://github.com/ethereum/wiki/wiki/JSON-RPC#parameters-22
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Default)]

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -85,7 +85,7 @@ impl BridgeContractMethod {
             BridgeContractMethod::CheckReferenceRate => b"checkReferenceRate",
             BridgeContractMethod::UpdateReferenceRate => b"updateReferenceRate",
             BridgeContractMethod::PublishRoot => b"publishRoot",
-            BridgeContractMethod::TriggerGrowth => b"TriggerGrowth",
+            BridgeContractMethod::TriggerGrowth => b"triggerGrowth",
             BridgeContractMethod::AddAuthor => b"addAuthor",
             BridgeContractMethod::RemoveAuthor => b"removeAuthor",
         }


### PR DESCRIPTION
## Proposed changes

Extract bridge contract names to Enum and fix Return type of `latest_finalised_ethereum_block`
## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
