### PR TITLE
fix: Tests setup for avn-offence handler

### DIFF
--- a/pallets/avn-offence-handler/src/lib.rs
+++ b/pallets/avn-offence-handler/src/lib.rs
@@ -35,18 +35,37 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
 
     // Public interface of this pallet
-    #[pallet::config]
+    #[pallet::config(with_default)]
     pub trait Config: frame_system::Config + session::historical::Config {
         /// The overarching event type.
+        #[pallet::no_default_bounds]
         type RuntimeEvent: From<Event<Self>>
             + Into<<Self as frame_system::Config>::RuntimeEvent>
             + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// A trait responsible for punishing malicious validators
+        #[pallet::no_default]
         type Enforcer: Enforcer<<Self as session::Config>::ValidatorId>;
 
         /// Weight information for the extrinsics in this pallet.
         type WeightInfo: WeightInfo;
+    }
+
+    /// Default implementations of [`DefaultConfig`], which can be used to implement [`Config`].
+    pub mod config_preludes {
+        use super::*;
+        use frame_support::derive_impl;
+        pub struct TestDefaultConfig;
+
+        #[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig, no_aggregated_types)]
+        impl frame_system::DefaultConfig for TestDefaultConfig {}
+
+        #[frame_support::register_default_impl(TestDefaultConfig)]
+        impl DefaultConfig for TestDefaultConfig {
+            #[inject_runtime_type]
+            type RuntimeEvent = ();
+            type WeightInfo = ();
+        }
     }
 
     #[pallet::pallet]

--- a/pallets/avn-offence-handler/src/mock.rs
+++ b/pallets/avn-offence-handler/src/mock.rs
@@ -1,19 +1,13 @@
 //Copyright 2022 Aventus Systems (UK) Ltd.
 
 use crate::{self as avn_offence_handler, *};
-use frame_support::parameter_types;
+use frame_support::{derive_impl, parameter_types};
 use sp_runtime::{DispatchError, DispatchResult};
 use sp_state_machine::BasicExternalities;
 
-use frame_system as system;
+use frame_system::{self as system, DefaultConfig};
 use pallet_session as session;
-use sp_core::H256;
-use sp_runtime::{
-    testing::UintAuthorityId,
-    traits::{BlakeTwo256, ConvertInto, IdentityLookup},
-    BuildStorage,
-};
-
+use sp_runtime::{testing::UintAuthorityId, traits::ConvertInto, BuildStorage};
 use std::cell::RefCell;
 
 pub const VALIDATOR_ID_1: u64 = 1;
@@ -33,24 +27,27 @@ frame_support::construct_runtime!(
 
 pub type ValidatorId = <TestRuntime as session::Config>::ValidatorId;
 
+#[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
+impl pallet_avn::Config for TestRuntime {}
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl system::Config for TestRuntime {
+    type Nonce = u64;
+    type Block = Block;
+}
+
+#[derive_impl(crate::config_preludes::TestDefaultConfig as avn_offence_handler::DefaultConfig)]
 impl Config for TestRuntime {
-    type RuntimeEvent = RuntimeEvent;
     type Enforcer = Self;
-    type WeightInfo = ();
 }
 
 impl pallet_session::historical::Config for TestRuntime {
     type FullIdentification = u64;
     type FullIdentificationOf = ConvertInto;
-}
-
-impl pallet_avn::Config for TestRuntime {
-    type RuntimeEvent = RuntimeEvent;
-    type AuthorityId = UintAuthorityId;
-    type EthereumPublicKeyChecker = ();
-    type NewSessionHandler = ();
-    type DisabledValidatorChecker = ();
-    type WeightInfo = ();
 }
 
 pub struct TestSessionManager;
@@ -78,36 +75,6 @@ impl session::Config for TestRuntime {
     type ValidatorIdOf = ConvertInto;
     type NextSessionRotation = session::PeriodicSessions<Period, Offset>;
     type WeightInfo = ();
-}
-
-parameter_types! {
-    pub const BlockHashCount: u64 = 250;
-}
-
-impl system::Config for TestRuntime {
-    type BaseCallFilter = frame_support::traits::Everything;
-    type BlockWeights = ();
-    type BlockLength = ();
-    type DbWeight = ();
-    type RuntimeOrigin = RuntimeOrigin;
-    type RuntimeCall = RuntimeCall;
-    type Nonce = u64;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type AccountId = u64;
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type Block = Block;
-    type RuntimeEvent = RuntimeEvent;
-    type BlockHashCount = BlockHashCount;
-    type Version = ();
-    type PalletInfo = PalletInfo;
-    type AccountData = ();
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type SystemWeightInfo = ();
-    type SS58Prefix = ();
-    type OnSetCode = ();
-    type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 impl Enforcer<ValidatorId> for TestRuntime {


### PR DESCRIPTION
## Proposed changes

Additionally:
- Uses default test config for mocks
- Introduces and uses default test config for the pallet
