### PR TITLE
fix: Adds missing handler in token manager

### DIFF
--- a/pallets/token-manager/src/lib.rs
+++ b/pallets/token-manager/src/lib.rs
@@ -1220,6 +1220,10 @@ impl<T: Config> TokenInterface<T::TokenId, T::AccountId> for Pallet<T> {
                 let lifted_data = LiftedData::new(d.token_contract, d.receiver_address, d.amount);
                 return Self::process_lift(event, &lifted_data)
             },
+            EventData::LogErc20Transfer(d) => {
+                let lifted_data = LiftedData::new(d.token_contract, d.receiver_address, d.amount);
+                return Self::process_lift(event, &lifted_data)
+            },
 
             // Any other event should not be calling this hook, they should use the regular lift
             // pathway


### PR DESCRIPTION
## Proposed changes

Adds the TokenInterface handler in token manager for auto-lifts of erc20 transfers

Related Jira ticket:
- SYS-4349

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->
