### PR TITLE
feat: Support multi-pallet ProcessedEvents 

### DIFF
--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -725,7 +725,7 @@ impl<ValidatorId: Member> Enforcer<ValidatorId> for () {
 
 pub trait ProcessedEventsChecker {
     fn processed_event_exists(event_id: &EthEventId) -> bool;
-    fn add_processed_event(event_id: &EthEventId, accepted: bool);
+    fn add_processed_event(event_id: &EthEventId, accepted: bool) -> Result<(), ()>;
 }
 
 impl ProcessedEventsChecker for () {
@@ -733,7 +733,9 @@ impl ProcessedEventsChecker for () {
         false
     }
 
-    fn add_processed_event(_event_id: &EthEventId, _accepted: bool) {}
+    fn add_processed_event(_event_id: &EthEventId, _accepted: bool) -> Result<(), ()> {
+        Ok(())
+    }
 }
 
 pub trait OnGrowthLiftedHandler<Balance> {

--- a/pallets/eth-bridge/src/tests/mock.rs
+++ b/pallets/eth-bridge/src/tests/mock.rs
@@ -115,7 +115,7 @@ impl Config for TestRuntime {
     type AccountToBytesConvert = U64To32BytesConverter;
     type BridgeInterfaceNotification = TestRuntime;
     type ReportCorroborationOffence = OffenceHandler;
-    type ProcessedEventsChecker = Self;
+    type ProcessedEventsChecker = EthBridge;
     type EthereumEventsFilter = ();
 }
 
@@ -498,23 +498,5 @@ impl BridgeInterfaceNotification for TestRuntime {
         }
 
         Ok(())
-    }
-}
-
-thread_local! {
-    static PROCESSED_EVENTS: RefCell<Vec<(EthEventId, bool)>> = RefCell::new(vec![]);
-}
-
-pub fn insert_to_mock_processed_events(event_id: &EthEventId, processed: bool) {
-    PROCESSED_EVENTS.with(|l| l.borrow_mut().push((event_id.clone(), processed)));
-}
-
-impl ProcessedEventsChecker for TestRuntime {
-    fn processed_event_exists(event_id: &EthEventId) -> bool {
-        PROCESSED_EVENTS.with(|l| l.borrow().iter().any(|(event, _processed)| event == event_id))
-    }
-
-    fn add_processed_event(event_id: &EthEventId, accepted: bool) {
-        insert_to_mock_processed_events(event_id, accepted);
     }
 }

--- a/pallets/ethereum-events/src/lib.rs
+++ b/pallets/ethereum-events/src/lib.rs
@@ -1531,7 +1531,7 @@ impl<T: Config> Pallet<T> {
     }
 
     fn is_event_contract_valid(contract_address: &H160, event_id: &EthEventId) -> bool {
-        let event_type = ValidEvents::try_from(&event_id.signature);
+        let event_type = ValidEvents::try_from(&event_id.signature).ok();
         if let Some(event_type) = event_type {
             if event_type.is_nft_event() {
                 return <NftT1Contracts<T>>::contains_key(contract_address)
@@ -1619,8 +1619,10 @@ impl<T: Config> ProcessedEventsChecker for Pallet<T> {
             Self::get_pending_event_index(event_id).is_ok()
     }
 
-    fn add_processed_event(event_id: &EthEventId, accepted: bool) {
+    fn add_processed_event(event_id: &EthEventId, accepted: bool) -> Result<(), ()> {
+        ensure!(!Self::processed_event_exists(event_id), ());
         <ProcessedEvents<T>>::insert(event_id.clone(), accepted);
+        Ok(())
     }
 }
 

--- a/pallets/ethereum-events/src/mock.rs
+++ b/pallets/ethereum-events/src/mock.rs
@@ -137,6 +137,7 @@ impl Config for TestRuntime {
     type Signature = Signature;
     type WeightInfo = ();
     type EthereumEventsFilter = MyEthereumEventsFilter;
+    type ProcessedEventsChecker = EthereumEvents;
 }
 
 impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for TestRuntime
@@ -414,10 +415,6 @@ impl EthereumEvents {
             signature: ValidEvents::AddedValidator.signature(),
             transaction_hash: H256::from([seed; 32]),
         }
-    }
-
-    pub fn insert_to_processed_events(to_insert: &EthEventId) {
-        <ProcessedEvents<TestRuntime>>::insert(to_insert.clone(), true);
     }
 
     pub fn has_events_to_validate() -> bool {

--- a/pallets/ethereum-events/src/tests/tests.rs
+++ b/pallets/ethereum-events/src/tests/tests.rs
@@ -232,7 +232,7 @@ fn test_event_exists_in_system_entry_in_processed_queue() {
             signature: ValidEvents::AddedValidator.signature(),
             transaction_hash: H256::random(),
         };
-        EthereumEvents::insert_to_processed_events(&event_id);
+        assert_ok!(EthereumEvents::add_processed_event(&event_id, true));
         // Test with an event that exists in Processed Events only
         assert!(EthereumEvents::event_exists_in_system(&event_id));
         assert!(!EthereumEvents::has_events_to_check());

--- a/pallets/nft-manager/src/tests/mock.rs
+++ b/pallets/nft-manager/src/tests/mock.rs
@@ -130,7 +130,9 @@ impl ProcessedEventsChecker for TestRuntime {
     fn processed_event_exists(event_id: &EthEventId) -> bool {
         return PROCESSED_EVENTS.with(|l| l.borrow_mut().iter().any(|event| event == event_id))
     }
-    fn add_processed_event(_event_id: &EthEventId, _accepted: bool) {}
+    fn add_processed_event(_event_id: &EthEventId, _accepted: bool) -> Result<(), ()> {
+        Ok(())
+    }
 }
 
 pub struct TestAccount {

--- a/pallets/token-manager/src/mock.rs
+++ b/pallets/token-manager/src/mock.rs
@@ -382,7 +382,9 @@ impl ProcessedEventsChecker for TestRuntime {
         return PROCESSED_EVENTS.with(|l| l.borrow_mut().iter().any(|event| event == event_id))
     }
 
-    fn add_processed_event(_event_id: &EthEventId, _accepted: bool) {}
+    fn add_processed_event(_event_id: &EthEventId, _accepted: bool) -> Result<(), ()> {
+        Ok(())
+    }
 }
 
 impl TokenManager {

--- a/pallets/validators-manager/src/tests/mock.rs
+++ b/pallets/validators-manager/src/tests/mock.rs
@@ -357,7 +357,9 @@ impl ProcessedEventsChecker for TestRuntime {
         })
     }
 
-    fn add_processed_event(_event_id: &EthEventId, _accepted: bool) {}
+    fn add_processed_event(_event_id: &EthEventId, _accepted: bool) -> Result<(), ()> {
+        Ok(())
+    }
 }
 
 // TODO: Do we need to test the ECDSA sig verification logic here? If so, replace this with a call

--- a/primitives/avn-common/src/event_types.rs
+++ b/primitives/avn-common/src/event_types.rs
@@ -155,32 +155,6 @@ impl ValidEvents {
         }
     }
 
-    pub fn try_from(signature: &H256) -> Option<ValidEvents> {
-        if signature == &ValidEvents::AddedValidator.signature() {
-            return Some(ValidEvents::AddedValidator)
-        } else if signature == &ValidEvents::Lifted.signature() {
-            return Some(ValidEvents::Lifted)
-        } else if signature == &ValidEvents::NftMint.signature() {
-            return Some(ValidEvents::NftMint)
-        } else if signature == &ValidEvents::NftTransferTo.signature() {
-            return Some(ValidEvents::NftTransferTo)
-        } else if signature == &ValidEvents::NftCancelListing.signature() {
-            return Some(ValidEvents::NftCancelListing)
-        } else if signature == &ValidEvents::NftEndBatchListing.signature() {
-            return Some(ValidEvents::NftEndBatchListing)
-        } else if signature == &ValidEvents::AvtGrowthLifted.signature() {
-            return Some(ValidEvents::AvtGrowthLifted)
-        } else if signature == &ValidEvents::AvtLowerClaimed.signature() {
-            return Some(ValidEvents::AvtLowerClaimed)
-        } else if signature == &ValidEvents::LiftedToPredictionMarket.signature() {
-            return Some(ValidEvents::LiftedToPredictionMarket)
-        } else if signature == &ValidEvents::Erc20DirectTransfer.signature() {
-            return Some(ValidEvents::Erc20DirectTransfer)
-        } else {
-            return None
-        }
-    }
-
     pub fn is_nft_event(&self) -> bool {
         match *self {
             ValidEvents::NftMint |
@@ -199,6 +173,18 @@ impl ValidEvents {
         match *self {
             ValidEvents::Erc20DirectTransfer => false,
             _ => true,
+        }
+    }
+}
+
+impl TryFrom<&H256> for ValidEvents {
+    type Error = ();
+
+    fn try_from(value: &H256) -> Result<Self, Self::Error> {
+        if let Some(e) = ValidEvents::iter().find(|event| event.signature() == *value) {
+            Ok(e)
+        } else {
+            Err(())
         }
     }
 }
@@ -793,6 +779,14 @@ impl Default for CheckResult {
     }
 }
 
+// Data type for storing an Ethereum transaction ID.
+pub type EthTransactionId = H256;
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+pub struct EthProcessedEvent {
+    pub id: ValidEvents,
+    pub accepted: bool,
+}
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
 // Note: strictly speaking, different contracts can have events with the same signature, which would
 // suggest that the contract should be part of the EventId.
@@ -803,7 +797,7 @@ impl Default for CheckResult {
 pub struct EthEventId {
     pub signature: H256, /* this is the Event Signature, as in ethereum's Topic0. It is not a
                           * cryptographic signature */
-    pub transaction_hash: H256,
+    pub transaction_hash: EthTransactionId,
 }
 
 impl EthEventId {

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -488,7 +488,7 @@ impl pallet_parachain_staking::Config for Runtime {
     type MinNominationPerCollator = ConstU128<1>;
     type RewardPotId = RewardPotId;
     type ErasPerGrowthPeriod = ConstU32<30>; // 30 eras (~ 1 month if era = 1 day)
-    type ProcessedEventsChecker = EthereumEvents;
+    type ProcessedEventsChecker = EthBridge;
     type Public = <Signature as sp_runtime::traits::Verify>::Signer;
     type Signature = Signature;
     type CollatorSessionRegistration = Session;
@@ -597,7 +597,7 @@ parameter_types! {
 
 impl pallet_validators_manager::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type ProcessedEventsChecker = EthereumEvents;
+    type ProcessedEventsChecker = EthBridge;
     type VotingPeriod = ValidatorManagerVotingPeriod;
     type AccountToBytesConvert = Avn;
     type ValidatorRegistrationNotifier = AvnOffenceHandler;
@@ -663,7 +663,7 @@ impl pallet_token_manager::pallet::Config for Runtime {
     type Currency = Balances;
     type TokenBalance = Balance;
     type TokenId = EthAddress;
-    type ProcessedEventsChecker = EthereumEvents;
+    type ProcessedEventsChecker = EthBridge;
     type Public = <Signature as sp_runtime::traits::Verify>::Signer;
     type Signature = Signature;
     type OnGrowthLiftedHandler = ParachainStaking;
@@ -679,7 +679,7 @@ impl pallet_token_manager::pallet::Config for Runtime {
 impl pallet_nft_manager::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
-    type ProcessedEventsChecker = EthereumEvents;
+    type ProcessedEventsChecker = EthBridge;
     type Public = <Signature as sp_runtime::traits::Verify>::Signer;
     type Signature = Signature;
     type BatchBound = pallet_nft_manager::BatchNftBound;
@@ -703,7 +703,7 @@ impl pallet_eth_bridge::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type MinEthBlockConfirmation = MinEthBlockConfirmation;
-    type ProcessedEventsChecker = EthereumEvents;
+    type ProcessedEventsChecker = EthBridge;
     type AccountToBytesConvert = Avn;
     type ReportCorroborationOffence = Offences;
     type TimeProvider = pallet_timestamp::Pallet<Runtime>;


### PR DESCRIPTION
## Proposed changes

- Extends EthBridge pallet to maintain processed events data.
- Updates runtimes to use either EthBridge or both pallets to check for
  processed events
- Updates the trait interface and aligns try_from implementation for
  ValidEvents
- Introduces new types to improve readability
- Updated `ProcessedEventsChecker` and the pallet to account for multiple
  storage items managing processed event data.
- Modified logic to validate processed events immediately before inserting
  and enhanced the trait to prevent overwriting.
- Added missing cleanup logic for the `challenges` storage item.

Related Jira ticket:
   - SYS-4111

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
