### PR TITLE
feat: Add processed events migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-lower-rpc"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "avn-service",
  "futures",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "avn-node-parachain"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "avn-lower-rpc",
  "avn-parachain-runtime",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
@@ -7014,7 +7014,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7042,7 +7042,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-anchor"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7092,7 +7092,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7121,7 +7121,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -7441,7 +7441,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge-runtime-api"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "frame-support",
  "pallet-avn",
@@ -7455,7 +7455,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "env_logger 0.10.0",
  "frame-benchmarking",
@@ -7653,7 +7653,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7782,7 +7782,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8061,7 +8061,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8130,7 +8130,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8239,7 +8239,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -13058,7 +13058,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6968,7 +6968,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-authors-manager"
-version = "6.6.1"
+version = "6.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "6.6.1"
+version = "6.7.0"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -738,8 +738,7 @@ impl EventMigration {
 pub trait ProcessedEventsChecker {
     fn processed_event_exists(event_id: &EthEventId) -> bool;
     fn add_processed_event(event_id: &EthEventId, accepted: bool) -> Result<(), ()>;
-    fn migrate_processed_events_batch() -> Option<BoundedVec<EventMigration, ProcessingBatchBound>>
-    {
+    fn get_events_to_migrate() -> Option<BoundedVec<EventMigration, ProcessingBatchBound>> {
         None
     }
 }

--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -31,7 +31,7 @@ use frame_system::{
 pub use pallet::*;
 use sp_application_crypto::RuntimeAppPublic;
 use sp_avn_common::{
-    bounds::MaximumValidatorsBound,
+    bounds::{MaximumValidatorsBound, ProcessingBatchBound},
     event_types::{EthEvent, EthEventId, Validator},
     ocw_lock::{self as OcwLock, OcwStorageError},
     recover_public_key_from_ecdsa_signature, DEFAULT_EXTERNAL_SERVICE_PORT_NUMBER,
@@ -46,7 +46,7 @@ use sp_runtime::{
         Duration,
     },
     traits::Member,
-    DispatchError, WeakBoundedVec,
+    BoundedVec, DispatchError, WeakBoundedVec,
 };
 use sp_std::prelude::*;
 
@@ -723,9 +723,25 @@ impl<ValidatorId: Member> Enforcer<ValidatorId> for () {
     }
 }
 
+pub struct EventMigration {
+    pub entry_return_impl: fn(&EthEventId, bool),
+    pub event_id: EthEventId,
+    pub outcome: bool,
+}
+
+impl EventMigration {
+    pub fn return_entry(&self) {
+        (self.entry_return_impl)(&self.event_id, self.outcome);
+    }
+}
+
 pub trait ProcessedEventsChecker {
     fn processed_event_exists(event_id: &EthEventId) -> bool;
     fn add_processed_event(event_id: &EthEventId, accepted: bool) -> Result<(), ()>;
+    fn migrate_processed_events_batch() -> Option<BoundedVec<EventMigration, ProcessingBatchBound>>
+    {
+        None
+    }
 }
 
 impl ProcessedEventsChecker for () {

--- a/pallets/eth-bridge/src/default_weights.rs
+++ b/pallets/eth-bridge/src/default_weights.rs
@@ -47,6 +47,8 @@ pub trait WeightInfo {
 	fn submit_ethereum_events_and_process_batch(c: u32, e: u32, ) -> Weight;
 	fn submit_latest_ethereum_block(c: u32, ) -> Weight;
 	fn submit_latest_ethereum_block_with_quorum(c: u32, ) -> Weight;
+	fn base_on_idle() -> Weight;
+	fn migrate_events_batch(n: u32, ) -> Weight;
 }
 
 /// Weights for pallet_eth_bridge using the Substrate node and recommended hardware.
@@ -245,6 +247,38 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
+	/// Storage: `EthereumEvents::ProcessedEvents` (r:5 w:4)
+	/// Proof: `EthereumEvents::ProcessedEvents` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	/// Storage: `EthBridge::ProcessedEthereumEvents` (r:4 w:4)
+	/// Proof: `EthBridge::ProcessedEthereumEvents` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	fn base_on_idle() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `689`
+		//  Estimated: `13770`
+		// Minimum execution time: 73_378_000 picoseconds.
+		Weight::from_parts(75_317_000, 13770)
+			.saturating_add(T::DbWeight::get().reads(9_u64))
+			.saturating_add(T::DbWeight::get().writes(8_u64))
+	}
+	/// Storage: `EthBridge::ProcessedEthereumEvents` (r:64 w:60)
+	/// Proof: `EthBridge::ProcessedEthereumEvents` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	/// Storage: `EthereumEvents::ProcessedEvents` (r:64 w:0)
+	/// Proof: `EthereumEvents::ProcessedEvents` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	/// The range of component `n` is `[1, 100]`.
+	fn migrate_events_batch(n: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `578`
+		//  Estimated: `20585 + n * (1808 ±25)`
+		// Minimum execution time: 230_000 picoseconds.
+		Weight::from_parts(10_671_771, 20585)
+			// Standard Error: 86_583
+			.saturating_add(Weight::from_parts(11_027_073, 0).saturating_mul(n.into()))
+			.saturating_add(T::DbWeight::get().reads(14_u64))
+			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(n.into())))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
+			.saturating_add(Weight::from_parts(0, 1808).saturating_mul(n.into()))
+	}
 }
 
 // For backwards compatibility and tests.
@@ -441,5 +475,37 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(417_091, 0).saturating_mul(c.into()))
 			.saturating_add(RocksDbWeight::get().reads(5_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
+	}
+	/// Storage: `EthereumEvents::ProcessedEvents` (r:5 w:4)
+	/// Proof: `EthereumEvents::ProcessedEvents` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	/// Storage: `EthBridge::ProcessedEthereumEvents` (r:4 w:4)
+	/// Proof: `EthBridge::ProcessedEthereumEvents` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	fn base_on_idle() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `689`
+		//  Estimated: `13770`
+		// Minimum execution time: 73_378_000 picoseconds.
+		Weight::from_parts(75_317_000, 13770)
+			.saturating_add(RocksDbWeight::get().reads(9_u64))
+			.saturating_add(RocksDbWeight::get().writes(8_u64))
+	}
+	/// Storage: `EthBridge::ProcessedEthereumEvents` (r:64 w:60)
+	/// Proof: `EthBridge::ProcessedEthereumEvents` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	/// Storage: `EthereumEvents::ProcessedEvents` (r:64 w:0)
+	/// Proof: `EthereumEvents::ProcessedEvents` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	/// The range of component `n` is `[1, 100]`.
+	fn migrate_events_batch(n: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `578`
+		//  Estimated: `20585 + n * (1808 ±25)`
+		// Minimum execution time: 230_000 picoseconds.
+		Weight::from_parts(10_671_771, 20585)
+			// Standard Error: 86_583
+			.saturating_add(Weight::from_parts(11_027_073, 0).saturating_mul(n.into()))
+			.saturating_add(RocksDbWeight::get().reads(14_u64))
+			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(n.into())))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(n.into())))
+			.saturating_add(Weight::from_parts(0, 1808).saturating_mul(n.into()))
 	}
 }

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -744,8 +744,7 @@ pub mod pallet {
 
             meter.consume(base_on_idle);
 
-            if let Some(events_batch) = T::ProcessedEventsChecker::migrate_processed_events_batch()
-            {
+            if let Some(events_batch) = T::ProcessedEventsChecker::get_events_to_migrate() {
                 let weight = Self::migrate_events_batch(events_batch);
                 meter.consume(weight);
             }

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -739,7 +739,7 @@ pub mod pallet {
 
             let mut meter = WeightMeter::with_limit(remaining_weight);
             if !meter.can_consume(processing_unit) {
-                return Weight::zero();
+                return Weight::zero()
             }
 
             meter.consume(base_on_idle);

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -59,8 +59,12 @@ use alloc::{
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::convert::TryInto;
 use frame_support::{
-    dispatch::DispatchResultWithPostInfo, ensure, pallet_prelude::StorageVersion,
-    traits::IsSubType, BoundedBTreeSet, BoundedVec,
+    dispatch::DispatchResultWithPostInfo,
+    ensure,
+    pallet_prelude::{StorageVersion, Weight},
+    traits::IsSubType,
+    weights::WeightMeter,
+    BoundedBTreeSet, BoundedVec,
 };
 use frame_system::{
     ensure_none, ensure_root,
@@ -68,17 +72,17 @@ use frame_system::{
     pallet_prelude::{BlockNumberFor, OriginFor},
 };
 use pallet_avn::{
-    self as avn, BridgeInterface, BridgeInterfaceNotification, Error as avn_error, LowerParams,
-    ProcessedEventsChecker, MAX_VALIDATOR_ACCOUNTS,
+    self as avn, BridgeInterface, BridgeInterfaceNotification, Error as avn_error, EventMigration,
+    LowerParams, ProcessedEventsChecker, MAX_VALIDATOR_ACCOUNTS,
 };
 use pallet_session::historical::IdentificationTuple;
 use sp_staking::offence::ReportOffence;
 
 use sp_application_crypto::RuntimeAppPublic;
 use sp_avn_common::{
-    bounds::MaximumValidatorsBound,
+    bounds::{MaximumValidatorsBound, ProcessingBatchBound},
     event_discovery::*,
-    event_types::{EthEventId, EthProcessedEvent, EthTransactionId, ValidEvents, Validator},
+    event_types::{self, EthEventId, EthProcessedEvent, EthTransactionId, ValidEvents, Validator},
 };
 use sp_core::{ecdsa, ConstU32, H160, H256};
 use sp_io::hashing::keccak_256;
@@ -229,6 +233,10 @@ pub mod pallet {
         EventRejected {
             eth_event_id: EthEventId,
             reason: DispatchError,
+        },
+        EventMigrated {
+            eth_event_id: EthEventId,
+            accepted: bool,
         },
     }
 
@@ -718,6 +726,31 @@ pub mod pallet {
                 }
             }
         }
+
+        fn on_idle(_n: BlockNumberFor<T>, remaining_weight: Weight) -> Weight {
+            let base_on_idle = <T as pallet::Config>::WeightInfo::base_on_idle();
+
+            // the maximum cost of a processing unit
+            let processing_unit = base_on_idle.saturating_add(
+                <T as pallet::Config>::WeightInfo::migrate_events_batch(
+                    <ProcessingBatchBound as sp_core::Get<u32>>::get(),
+                ),
+            );
+
+            let mut meter = WeightMeter::with_limit(remaining_weight);
+            if !meter.can_consume(processing_unit) {
+                return Weight::zero();
+            }
+
+            meter.consume(base_on_idle);
+
+            if let Some(events_batch) = T::ProcessedEventsChecker::migrate_processed_events_batch()
+            {
+                let weight = Self::migrate_events_batch(events_batch);
+                meter.consume(weight);
+            }
+            meter.consumed()
+        }
     }
 
     fn save_active_request_to_storage<T: Config>(mut tx: ActiveRequestData<T>) {
@@ -1156,6 +1189,40 @@ impl<T: Config> Pallet<T> {
     pub fn get_bridge_contract() -> H160 {
         AVN::<T>::get_bridge_contract_address()
     }
+
+    pub fn migrate_events_batch(
+        events_batch: BoundedVec<EventMigration, ProcessingBatchBound>,
+    ) -> Weight {
+        let mut counter = 0;
+        events_batch.into_iter().for_each(|migration| {
+            counter.saturating_inc();
+            match T::ProcessedEventsChecker::add_processed_event(
+                &migration.event_id,
+                migration.outcome,
+            ) {
+                Ok(_) => {
+                    log::debug!(
+                        "Migrated processed event: {:?} to eth-bridge pallet",
+                        &migration.event_id
+                    );
+                    <Pallet<T>>::deposit_event(Event::EventMigrated {
+                        eth_event_id: migration.event_id,
+                        accepted: migration.outcome,
+                    });
+                },
+                Err(error) => {
+                    log::error!(
+                        "Error {:?} while migrating processed event: {:?} to eth-bridge pallet",
+                        error,
+                        &migration.event_id
+                    );
+                    migration.return_entry();
+                },
+            }
+        });
+
+        <T as pallet::Config>::WeightInfo::migrate_events_batch(counter)
+    }
 }
 
 impl<T: Config> ProcessedEventsChecker for Pallet<T> {
@@ -1164,10 +1231,25 @@ impl<T: Config> ProcessedEventsChecker for Pallet<T> {
     }
 
     fn add_processed_event(event_id: &EthEventId, accepted: bool) -> Result<(), ()> {
-        ensure!(!Self::processed_event_exists(event_id), ());
-        let id = ValidEvents::try_from(&event_id.signature)?;
-        <ProcessedEthereumEvents<T>>::insert(
-            event_id.transaction_hash.clone(),
+        let tx_hash = event_id.transaction_hash.to_owned();
+
+        // Data from other pallets may allow multiple entries of the same tx_id. We want to preserve
+        // the one that was accepted.
+        if let Some(processed_event) = ProcessedEthereumEvents::<T>::get(&tx_hash) {
+            if processed_event.accepted {
+                Err(())?
+            }
+        }
+
+        // Handle legacy lifts
+        let id = if event_types::LEGACY_LIFT_SIGNATURE.eq(&event_id.signature) {
+            ValidEvents::Lifted
+        } else {
+            ValidEvents::try_from(&event_id.signature)?
+        };
+
+        ProcessedEthereumEvents::<T>::insert(
+            event_id.transaction_hash.to_owned(),
             EthProcessedEvent { id, accepted },
         );
         Ok(())

--- a/pallets/ethereum-events/src/lib.rs
+++ b/pallets/ethereum-events/src/lib.rs
@@ -1664,7 +1664,7 @@ impl<T: Config> ProcessedEventsChecker for Pallet<T> {
         });
 
         if migration_batch.is_empty() {
-            return None;
+            return None
         }
         Some(BoundedVec::<EventMigration, ProcessingBatchBound>::truncate_from(migration_batch))
     }

--- a/pallets/ethereum-events/src/lib.rs
+++ b/pallets/ethereum-events/src/lib.rs
@@ -1659,13 +1659,13 @@ impl<T: Config> ProcessedEventsChecker for Pallet<T> {
             })
             .collect();
 
-        migration_batch.iter().for_each(|event_to_migrate| {
-            ProcessedEvents::<T>::remove(&event_to_migrate.event_id);
-        });
-
         if migration_batch.is_empty() {
             return None
         }
+
+        migration_batch.iter().for_each(|event_to_migrate| {
+            ProcessedEvents::<T>::remove(&event_to_migrate.event_id);
+        });
         Some(BoundedVec::<EventMigration, ProcessingBatchBound>::truncate_from(migration_batch))
     }
 }

--- a/pallets/ethereum-events/src/lib.rs
+++ b/pallets/ethereum-events/src/lib.rs
@@ -1645,8 +1645,7 @@ impl<T: Config> ProcessedEventsChecker for Pallet<T> {
         Ok(())
     }
 
-    fn migrate_processed_events_batch() -> Option<BoundedVec<EventMigration, ProcessingBatchBound>>
-    {
+    fn get_events_to_migrate() -> Option<BoundedVec<EventMigration, ProcessingBatchBound>> {
         let batch_size: u32 = ProcessingBatchBound::get();
         let entry_return =
             |event: &EthEventId, outcome: bool| ProcessedEvents::<T>::insert(event, outcome);

--- a/primitives/avn-common/src/event_types.rs
+++ b/primitives/avn-common/src/event_types.rs
@@ -14,6 +14,8 @@ const TWENTY_FOUR_BYTES: usize = 24; // needed for creating a u64
 const TWENTY_EIGHT_BYTES: usize = 28; // needed for creating a u32
 const DISCARDED_ZERO_BYTES: usize = 12; // Used to ignore the first 12 bytes of a 32-byte value when creating an Ethereum address.
 const BYTE_LENGTH: usize = 1; // the length of 1 byte
+pub const LEGACY_LIFT_SIGNATURE: H256 =
+    H256(hex!("8964776336bc2fa8ecaaf70b6f8e8450807efb1ff78f8b87980707aa821f0ec0"));
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -66,6 +66,8 @@ pub mod bounds {
     pub type VotingSessionIdBound = ConstU32<64>;
     /// Bound used for NFT external references
     pub type NftExternalRefBound = ConstU32<1024>;
+    /// Bound used for batch operations
+    pub type ProcessingBatchBound = ConstU32<64>;
 }
 
 #[derive(Debug)]

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -174,7 +174,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 81,
+    spec_version: 82,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -18,7 +18,9 @@ use scale_info::TypeInfo;
 use sp_runtime::RuntimeAppPublic;
 
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+use frame_support::BoundedVec;
 use sp_api::impl_runtime_apis;
+use sp_avn_common::bounds::ProcessingBatchBound;
 use sp_core::{crypto::KeyTypeId, ConstU128, OpaqueMetadata, H160};
 use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
@@ -1124,7 +1126,7 @@ cumulus_pallet_parachain_system::register_validate_block! {
     BlockExecutor = cumulus_pallet_aura_ext::BlockExecutor::<Runtime, Executive>,
 }
 
-use pallet_avn::ProcessedEventsChecker;
+use pallet_avn::{EventMigration, ProcessedEventsChecker};
 use sp_avn_common::event_types::EthEventId;
 
 pub struct ProcessedEventCustodian {}
@@ -1137,5 +1139,10 @@ impl ProcessedEventsChecker for ProcessedEventCustodian {
     fn add_processed_event(event_id: &EthEventId, accepted: bool) -> Result<(), ()> {
         frame_support::ensure!(!Self::processed_event_exists(event_id), ());
         EthBridge::add_processed_event(event_id, accepted)
+    }
+
+    fn migrate_processed_events_batch() -> Option<BoundedVec<EventMigration, ProcessingBatchBound>>
+    {
+        EthereumEvents::migrate_processed_events_batch()
     }
 }

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -1141,8 +1141,7 @@ impl ProcessedEventsChecker for ProcessedEventCustodian {
         EthBridge::add_processed_event(event_id, accepted)
     }
 
-    fn migrate_processed_events_batch() -> Option<BoundedVec<EventMigration, ProcessingBatchBound>>
-    {
-        EthereumEvents::migrate_processed_events_batch()
+    fn get_events_to_migrate() -> Option<BoundedVec<EventMigration, ProcessingBatchBound>> {
+        EthereumEvents::get_events_to_migrate()
     }
 }

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -179,7 +179,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    pallet_eth_bridge::migration::SetBlockRangeSize<Runtime>,
+    (),
 >;
 
 impl_opaque_keys! {

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -196,7 +196,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-test-parachain"),
     impl_name: create_runtime_str!("avn-test-parachain"),
     authoring_version: 1,
-    spec_version: 80,
+    spec_version: 82,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Proposed changes

This commit introduces the migration of processed events between the Ethereum Events and Eth-Bridge pallets.

Key details:
- The migration occurs during the `on_idle` callback.
- Failed migrations are restored to the original pallet for retry.
- In cases of multiple entries for the same key (transaction hash), the successfully processed entry takes precedence.
- Benchmarks for `on_idle` operations have been added, executed on a development machine.
- Benchmarks have been run locally on a Dev machine

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [x] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->
