### PR TITLE
feat: extend the client to include additional events on discovery

### DIFF
--- a/pallets/eth-bridge/runtime-api/src/lib.rs
+++ b/pallets/eth-bridge/runtime-api/src/lib.rs
@@ -26,6 +26,6 @@ sp_api::decl_runtime_apis! {
             latest_seen_block: u32,
             signature: sp_core::sr25519::Signature
         ) -> Option<()>;
-        fn partition_has_additional_events() -> Option<AdditionalEvents>;
+        fn additional_events() -> Option<AdditionalEvents>;
     }
 }

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -1036,9 +1036,9 @@ impl_runtime_apis! {
             EthBridge::submit_latest_ethereum_block_vote(author, latest_seen_block, signature.into()).ok()
         }
 
-        fn partition_has_additional_events() -> Option<AdditionalEvents> {
+        fn additional_events() -> Option<AdditionalEvents> {
             if let Some(active_eth_range) =  EthBridge::active_ethereum_range(){
-                Some((active_eth_range.additional_events))
+                Some(active_eth_range.additional_events)
             } else {
                 None
             }

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -1073,9 +1073,9 @@ impl_runtime_apis! {
             EthBridge::submit_latest_ethereum_block_vote(author, latest_seen_block, signature.into()).ok()
         }
 
-        fn partition_has_additional_events() -> Option<AdditionalEvents> {
+        fn additional_events() -> Option<AdditionalEvents> {
             if let Some(active_eth_range) =  EthBridge::active_ethereum_range(){
-                Some((active_eth_range.additional_events))
+                Some(active_eth_range.additional_events)
             } else {
                 None
             }


### PR DESCRIPTION
## Proposed changes

Extends the client to take into consideration the new api of additional events available from the runtime.
Upon receiving a list, the client will perform a search for that event and include it in the results if:
- the event is found
- its signature is part of the allowed ones
- the block number of the event is lower than the active range start limit

Jira ticket:
- SYS-4453

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->
