### PR TITLE
feat: Refactor additional transactions block constrains

### DIFF
--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -340,17 +340,20 @@ pub async fn identify_additional_event_info(
     let results = try_join_all(futures).await?;
 
     // check results, return early if any error occurred
-    let mut additional_events_receipts = Vec::new();
+    let mut additional_transactions_receipts = Vec::new();
     for result in results {
         match result {
-            Ok(Some(event)) => additional_events_receipts.push(event),
+            Ok(Some(event)) => additional_transactions_receipts.push(event),
             Ok(None) => {},
             Err(_) => return Err(AppError::ErrorGettingEventLogs),
         }
     }
 
-    log::debug!("🔭 Additional events found to report back: {:#?}", &additional_events_receipts);
-    Ok(additional_events_receipts)
+    log::debug!(
+        "🔭 Additional events found to report back: {:#?}",
+        &additional_transactions_receipts
+    );
+    Ok(additional_transactions_receipts)
 }
 
 pub async fn identify_additional_events(

--- a/pallets/eth-bridge/runtime-api/src/lib.rs
+++ b/pallets/eth-bridge/runtime-api/src/lib.rs
@@ -26,6 +26,6 @@ sp_api::decl_runtime_apis! {
             latest_seen_block: u32,
             signature: sp_core::sr25519::Signature
         ) -> Option<()>;
-        fn additional_events() -> Option<AdditionalEvents>;
+        fn additional_transactions() -> Option<AdditionalEvents>;
     }
 }

--- a/pallets/eth-bridge/src/benchmarking.rs
+++ b/pallets/eth-bridge/src/benchmarking.rs
@@ -272,6 +272,7 @@ fn setup_active_range<T: Config>(partition_index: u16) -> EthBlockRange {
         range: range.clone(),
         partition: partition_index,
         event_types_filter: T::EthereumEventsFilter::get(),
+        ..Default::default()
     });
 
     range
@@ -514,6 +515,7 @@ benchmarks! {
             },
             partition: 0,
             event_types_filter: T::EthereumEventsFilter::get(),
+            ..Default::default()
         };
 
         ensure!(ActiveEthereumRange::<T>::get().is_some(), "Active range not set");

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -696,7 +696,7 @@ pub mod pallet {
                     range: selected_range,
                     partition: 0,
                     event_types_filter: T::EthereumEventsFilter::get(),
-                    additional_events: AdditionalEthereumEventsQueue::<T>::take(),
+                    additional_transactions: AdditionalEthereumEventsQueue::<T>::take(),
                 });
 
                 let _ = SubmittedEthBlocks::<T>::clear(
@@ -922,12 +922,12 @@ pub mod pallet {
         approved_partition: &EthereumEventsPartition,
     ) {
         let next_active_range = if approved_partition.is_last() {
-            let additional_events = AdditionalEthereumEventsQueue::<T>::take();
+            let additional_transactions = AdditionalEthereumEventsQueue::<T>::take();
             ActiveEthRange {
                 range: active_range.range.next_range(),
                 partition: 0,
                 event_types_filter: T::EthereumEventsFilter::get(),
-                additional_events,
+                additional_transactions,
             }
         } else {
             ActiveEthRange {

--- a/pallets/eth-bridge/src/migration.rs
+++ b/pallets/eth-bridge/src/migration.rs
@@ -91,7 +91,7 @@ pub fn migrate_to_v3<T: Config>() -> Weight {
             range: old_range.range,
             partition: old_range.partition,
             event_types_filter: old_range.event_types_filter,
-            additional_events: Default::default(),
+            additional_transactions: Default::default(),
         });
         consumed_weight += T::DbWeight::get().writes(1);
     }

--- a/pallets/eth-bridge/src/migration.rs
+++ b/pallets/eth-bridge/src/migration.rs
@@ -84,6 +84,8 @@ pub fn set_block_range_size<T: Config>() -> Weight {
 }
 
 pub fn migrate_to_v3<T: Config>() -> Weight {
+    let mut consumed_weight: Weight = T::DbWeight::get().reads(1);
+
     if let Some(old_range) = v2::ActiveEthereumRange::<T>::take() {
         ActiveEthereumRange::<T>::put(ActiveEthRange {
             range: old_range.range,
@@ -91,8 +93,10 @@ pub fn migrate_to_v3<T: Config>() -> Weight {
             event_types_filter: old_range.event_types_filter,
             additional_events: Default::default(),
         });
-        return T::DbWeight::get().reads_writes(1, 1);
+        consumed_weight += T::DbWeight::get().writes(1);
     }
+    STORAGE_VERSION.put::<Pallet<T>>();
+    consumed_weight += T::DbWeight::get().writes(1);
 
-    T::DbWeight::get().reads(1)
+    consumed_weight
 }

--- a/pallets/eth-bridge/src/tests/event_listener_tests.rs
+++ b/pallets/eth-bridge/src/tests/event_listener_tests.rs
@@ -61,7 +61,7 @@ fn init_active_range() {
     ActiveEthereumRange::<TestRuntime>::put(ActiveEthRange {
         range: EthBlockRange { start_block: 1, length: 1000 },
         partition: 0,
-        event_types_filter: Default::default(),
+        ..Default::default()
     });
 }
 
@@ -95,7 +95,7 @@ impl DiscoveredEthContext {
         ActiveEthereumRange::<TestRuntime>::put(ActiveEthRange {
             range: active_range.range.next_range(),
             partition: 0,
-            event_types_filter: Default::default(),
+            ..Default::default()
         });
     }
     fn partitions(&self) -> Vec<EthereumEventsPartition> {

--- a/pallets/eth-bridge/src/tests/incoming_events_tests.rs
+++ b/pallets/eth-bridge/src/tests/incoming_events_tests.rs
@@ -24,7 +24,7 @@ fn init_active_range() {
             .collect::<BTreeSet<ValidEvents>>(),
         )
         .unwrap(),
-        additional_events: Default::default(),
+        additional_transactions: Default::default(),
     });
 }
 

--- a/pallets/eth-bridge/src/tests/incoming_events_tests.rs
+++ b/pallets/eth-bridge/src/tests/incoming_events_tests.rs
@@ -24,6 +24,7 @@ fn init_active_range() {
             .collect::<BTreeSet<ValidEvents>>(),
         )
         .unwrap(),
+        additional_events: Default::default(),
     });
 }
 

--- a/pallets/eth-bridge/src/types.rs
+++ b/pallets/eth-bridge/src/types.rs
@@ -152,5 +152,5 @@ pub enum AdminSettings {
     /// Remove the active request and allow the next request to be processed
     RemoveActiveRequest,
     /// Queue an additional ethereum event to be included in the next range
-    QueueAdditionalEthereumEvent(AdditionalEvent),
+    QueueAdditionalEthereumEvent(EthTransactionId),
 }

--- a/pallets/eth-bridge/src/types.rs
+++ b/pallets/eth-bridge/src/types.rs
@@ -134,7 +134,7 @@ pub struct ActiveEthRange {
     pub range: EthBlockRange,
     pub partition: u16,
     pub event_types_filter: EthBridgeEventsFilter,
-    pub additional_events: AdditionalEvents,
+    pub additional_transactions: AdditionalEvents,
 }
 
 impl ActiveEthRange {

--- a/primitives/avn-common/src/event_discovery.rs
+++ b/primitives/avn-common/src/event_discovery.rs
@@ -1,4 +1,7 @@
-use crate::{event_types::EthEventId, *};
+use crate::{
+    event_types::{EthEventId, EthTransactionId},
+    *,
+};
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use event_types::EthEvent;
@@ -148,44 +151,7 @@ pub fn encode_eth_event_submission_data<AccountId: Encode, Data: Encode>(
     (context, &account_id, data).encode()
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo, MaxEncodedLen)]
-pub struct AdditionalEvent {
-    pub event_id: EthEventId,
-    pub block: u32,
-}
-pub type AdditionalEvents = BoundedBTreeSet<AdditionalEvent, ConstU32<16>>;
-
-impl PartialOrd for AdditionalEvent {
-    fn partial_cmp(&self, other: &Self) -> Option<scale_info::prelude::cmp::Ordering> {
-        let ord_sig = self.event_id.signature.partial_cmp(&other.event_id.signature);
-
-        if let Some(core::cmp::Ordering::Equal) = ord_sig {
-            return ord_sig
-        }
-
-        match self.block.partial_cmp(&other.block) {
-            Some(core::cmp::Ordering::Equal) => {},
-            ord => return ord,
-        }
-        ord_sig
-    }
-}
-
-impl Ord for AdditionalEvent {
-    fn cmp(&self, other: &Self) -> scale_info::prelude::cmp::Ordering {
-        let ord_sig = self.event_id.signature.cmp(&other.event_id.signature);
-
-        if let core::cmp::Ordering::Equal = ord_sig {
-            return ord_sig
-        }
-
-        match self.block.cmp(&other.block) {
-            core::cmp::Ordering::Equal => {},
-            ord => return ord,
-        }
-        ord_sig
-    }
-}
+pub type AdditionalEvents = BoundedBTreeSet<EthTransactionId, ConstU32<16>>;
 
 pub mod events_helpers {
     use super::*;

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -1036,9 +1036,9 @@ impl_runtime_apis! {
             EthBridge::submit_latest_ethereum_block_vote(author, latest_seen_block, signature.into()).ok()
         }
 
-        fn additional_events() -> Option<AdditionalEvents> {
+        fn additional_transactions() -> Option<AdditionalEvents> {
             if let Some(active_eth_range) =  EthBridge::active_ethereum_range(){
-                Some(active_eth_range.additional_events)
+                Some(active_eth_range.additional_transactions)
             } else {
                 None
             }

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -1073,9 +1073,9 @@ impl_runtime_apis! {
             EthBridge::submit_latest_ethereum_block_vote(author, latest_seen_block, signature.into()).ok()
         }
 
-        fn additional_events() -> Option<AdditionalEvents> {
+        fn additional_transactions() -> Option<AdditionalEvents> {
             if let Some(active_eth_range) =  EthBridge::active_ethereum_range(){
-                Some(active_eth_range.additional_events)
+                Some(active_eth_range.additional_transactions)
             } else {
                 None
             }


### PR DESCRIPTION
## Proposed changes
- Transfer responsibility for checking if an additional event is within the range from `sudo` and client to the runtime.
- Simplify input by requiring only transaction IDs for the queues.
- Runtime dictates the dataset that node clients will attempt to discover.
- Ensure valid transactions are included in the range and trigger an event.
- Updates tests and benchmarks accordingly.

 Jira ticket:
 - SYS-4453
