### PR TITLE
fix: Bumps the version of runtime api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-lower-rpc"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "avn-service",
  "futures",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "avn-node-parachain"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "avn-lower-rpc",
  "avn-parachain-runtime",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
@@ -6968,7 +6968,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-authors-manager"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7014,7 +7014,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7042,7 +7042,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-anchor"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7092,7 +7092,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7122,7 +7122,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7413,7 +7413,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -7442,7 +7442,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge-runtime-api"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-support",
  "pallet-avn",
@@ -7456,7 +7456,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "env_logger 0.10.0",
  "frame-benchmarking",
@@ -7654,7 +7654,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7783,7 +7783,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8062,7 +8062,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8240,7 +8240,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -13059,7 +13059,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "6.8.0"
+version = "6.8.1"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/pallets/eth-bridge/runtime-api/src/lib.rs
+++ b/pallets/eth-bridge/runtime-api/src/lib.rs
@@ -6,7 +6,7 @@ use sp_core::{H160, H256};
 
 sp_api::decl_runtime_apis! {
 
-    #[api_version(1)]
+    #[api_version(2)]
     pub trait EthEventHandlerApi<AccountId>
             where
         AccountId: Codec,

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -177,7 +177,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 86,
+    spec_version: 87,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -197,7 +197,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-test-parachain"),
     impl_name: create_runtime_str!("avn-test-parachain"),
     authoring_version: 1,
-    spec_version: 86,
+    spec_version: 87,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Proposed changes

Increase the runtime api and the way the client handles it. This enables the client binary to be forwards compatible with the introduction of the new API.

Jira ticket:
- SYS-4453

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [x] Patch release <!---i.ex v1.0.0 => v1.0.1-->

