### PR TITLE
chore: refactor and clean up Ethereum filters

### DIFF
--- a/pallets/authors-manager/src/mock.rs
+++ b/pallets/authors-manager/src/mock.rs
@@ -224,7 +224,7 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
-    type EthereumEventsFilter = ();
+    type ProcessedEventsHandler = ();
 }
 
 impl BridgeInterfaceNotification for TestRuntime {

--- a/pallets/avn-anchor/src/mock.rs
+++ b/pallets/avn-anchor/src/mock.rs
@@ -279,7 +279,7 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
-    type EthereumEventsFilter = ();
+    type ProcessedEventsHandler = ();
 }
 
 impl pallet_timestamp::Config for TestRuntime {

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -234,7 +234,7 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
-    type EthereumEventsFilter = ();
+    type ProcessedEventsHandler = ();
 }
 
 impl pallet_timestamp::Config for TestRuntime {

--- a/pallets/eth-bridge/src/benchmarking.rs
+++ b/pallets/eth-bridge/src/benchmarking.rs
@@ -271,7 +271,7 @@ fn setup_active_range<T: Config>(partition_index: u16) -> EthBlockRange {
     ActiveEthereumRange::<T>::put(ActiveEthRange {
         range: range.clone(),
         partition: partition_index,
-        event_types_filter: T::EthereumEventsFilter::get(),
+        event_types_filter: T::ProcessedEventsHandler::get(),
         ..Default::default()
     });
 
@@ -514,7 +514,7 @@ benchmarks! {
                 length: eth_block_range_size,
             },
             partition: 0,
-            event_types_filter: T::EthereumEventsFilter::get(),
+            event_types_filter: T::ProcessedEventsHandler::get(),
             ..Default::default()
         };
 

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -191,7 +191,7 @@ pub mod pallet {
             CorroborationOffence<IdentificationTuple<Self>>,
         >;
         type ProcessedEventsChecker: ProcessedEventsChecker;
-        type EthereumEventsFilter: EthereumEventsFilterTrait;
+        type ProcessedEventsHandler: EthereumEventsFilterTrait;
     }
 
     #[pallet::event]
@@ -694,7 +694,7 @@ pub mod pallet {
                 ActiveEthereumRange::<T>::put(ActiveEthRange {
                     range: selected_range,
                     partition: 0,
-                    event_types_filter: T::EthereumEventsFilter::get(),
+                    event_types_filter: T::ProcessedEventsHandler::get(),
                     additional_transactions: AdditionalEthereumEventsQueue::<T>::take(),
                 });
 
@@ -926,7 +926,7 @@ pub mod pallet {
             ActiveEthRange {
                 range: active_range.range.next_range(),
                 partition: 0,
-                event_types_filter: T::EthereumEventsFilter::get(),
+                event_types_filter: T::ProcessedEventsHandler::get(),
                 additional_transactions,
             }
         } else {

--- a/pallets/eth-bridge/src/tests/mock.rs
+++ b/pallets/eth-bridge/src/tests/mock.rs
@@ -12,6 +12,7 @@ use pallet_avn::{testing::U64To32BytesConverter, EthereumPublicKeyChecker};
 use pallet_session as session;
 use parking_lot::RwLock;
 use sp_avn_common::{
+    event_discovery::filters::AllPrimaryEventsFilter,
     event_types::{EthEvent, EthEventId, LiftedData, ValidEvents},
     BridgeContractMethod,
 };
@@ -107,7 +108,7 @@ impl Config for TestRuntime {
     type BridgeInterfaceNotification = TestRuntime;
     type ReportCorroborationOffence = OffenceHandler;
     type ProcessedEventsChecker = EthBridge;
-    type EthereumEventsFilter = ();
+    type ProcessedEventsHandler = AllPrimaryEventsFilter;
 }
 
 impl system::Config for TestRuntime {

--- a/pallets/ethereum-events/src/lib.rs
+++ b/pallets/ethereum-events/src/lib.rs
@@ -195,7 +195,7 @@ pub mod pallet {
         /// Weight information for the extrinsics in this pallet.
         type WeightInfo: WeightInfo;
         type ProcessedEventsChecker: ProcessedEventsChecker;
-        type EthereumEventsFilter: EthereumEventsFilterTrait;
+        type ProcessedEventsHandler: EthereumEventsFilterTrait;
     }
 
     #[pallet::pallet]
@@ -1519,8 +1519,8 @@ impl<T: Config> Pallet<T> {
 
     /// Adds an event: tx_hash must be a nonzero hash
     fn add_event(event_type: ValidEvents, tx_hash: H256, sender: T::AccountId) -> DispatchResult {
-        let filter = T::EthereumEventsFilter::get_primary();
-        ensure!(!filter.contains(&event_type), Error::<T>::ErrorAddingEthereumLog);
+        let filter = T::ProcessedEventsHandler::get_primary();
+        ensure!(filter.contains(&event_type), Error::<T>::ErrorAddingEthereumLog);
         ensure!(event_type.is_primary(), Error::<T>::InvalidEventToProcess);
 
         let event_id = EthEventId { signature: event_type.signature(), transaction_hash: tx_hash };

--- a/pallets/ethereum-events/src/mock.rs
+++ b/pallets/ethereum-events/src/mock.rs
@@ -31,8 +31,8 @@ use sp_staking::{
 use avn::AvnBridgeContractAddress;
 use pallet_avn::{self as avn, Error as avn_error};
 use sp_avn_common::{
-    bounds::MaximumValidatorsBound, event_types::EthEvent, EthQueryRequest, EthQueryResponseType,
-    FeePaymentHandler,
+    bounds::MaximumValidatorsBound, event_discovery::filters::AllEventsFilter,
+    event_types::EthEvent, EthQueryRequest, EthQueryResponseType, FeePaymentHandler,
 };
 use sp_io::TestExternalities;
 
@@ -120,9 +120,8 @@ pub struct MyEthereumEventsFilter;
 
 impl EthereumEventsFilterTrait for MyEthereumEventsFilter {
     fn get() -> EthBridgeEventsFilter {
-        let allowed_events: BTreeSet<ValidEvents> =
-            vec![ValidEvents::AvtLowerClaimed].into_iter().collect();
-
+        let mut allowed_events: BTreeSet<ValidEvents> = AllEventsFilter::get().into_inner();
+        allowed_events.retain(|e| *e != ValidEvents::AvtLowerClaimed);
         EthBridgeEventsFilter::try_from(allowed_events).unwrap_or_default()
     }
 }
@@ -136,7 +135,7 @@ impl Config for TestRuntime {
     type Public = AccountId;
     type Signature = Signature;
     type WeightInfo = ();
-    type EthereumEventsFilter = MyEthereumEventsFilter;
+    type ProcessedEventsHandler = MyEthereumEventsFilter;
     type ProcessedEventsChecker = EthereumEvents;
 }
 

--- a/pallets/parachain-staking/src/tests/mock.rs
+++ b/pallets/parachain-staking/src/tests/mock.rs
@@ -367,7 +367,7 @@ impl pallet_eth_bridge::Config for Test {
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
-    type EthereumEventsFilter = ();
+    type ProcessedEventsHandler = ();
 }
 
 impl pallet_timestamp::Config for Test {

--- a/pallets/summary/src/tests/mock.rs
+++ b/pallets/summary/src/tests/mock.rs
@@ -462,7 +462,7 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = OffenceHandler;
     type ProcessedEventsChecker = ();
-    type EthereumEventsFilter = ();
+    type ProcessedEventsHandler = ();
 }
 
 impl pallet_timestamp::Config for TestRuntime {

--- a/pallets/token-manager/src/mock.rs
+++ b/pallets/token-manager/src/mock.rs
@@ -307,7 +307,7 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
-    type EthereumEventsFilter = ();
+    type ProcessedEventsHandler = ();
 }
 
 impl pallet_timestamp::Config for TestRuntime {

--- a/pallets/validators-manager/src/tests/mock.rs
+++ b/pallets/validators-manager/src/tests/mock.rs
@@ -253,7 +253,7 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
-    type EthereumEventsFilter = ();
+    type ProcessedEventsHandler = ();
 }
 
 impl BridgeInterfaceNotification for TestRuntime {

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -73,8 +73,8 @@ use pallet_avn::sr25519::AuthorityId as AvnId;
 use pallet_avn_proxy::ProvableProxy;
 use sp_avn_common::{
     event_discovery::{
-        AdditionalEvents, EthBlockRange, EthBridgeEventsFilter, EthereumEventsFilterTrait,
-        EthereumEventsPartition,
+        filters::{AllEventsFilter, NoEventsFilter},
+        AdditionalEvents, EthBlockRange, EthBridgeEventsFilter, EthereumEventsPartition,
     },
     event_types::ValidEvents,
     InnerCallValidator, Proof,
@@ -116,26 +116,6 @@ where
             }
             <ToStakingPot<R> as OnUnbalanced<_>>::on_unbalanced(fees);
         }
-    }
-}
-
-pub struct EthBridgeTestRuntimeEventsFilter;
-impl EthereumEventsFilterTrait for EthBridgeTestRuntimeEventsFilter {
-    fn get() -> EthBridgeEventsFilter {
-        let allowed_events: BTreeSet<ValidEvents> = vec![
-            ValidEvents::AddedValidator,
-            ValidEvents::Lifted,
-            ValidEvents::AvtGrowthLifted,
-            ValidEvents::AvtLowerClaimed,
-            ValidEvents::NftMint,
-            ValidEvents::NftTransferTo,
-            ValidEvents::NftCancelListing,
-            ValidEvents::NftEndBatchListing,
-        ]
-        .into_iter()
-        .collect();
-
-        EthBridgeEventsFilter::try_from(allowed_events).unwrap_or_default()
     }
 }
 
@@ -589,7 +569,7 @@ impl pallet_ethereum_events::Config for Runtime {
     type Signature = Signature;
     type ReportInvalidEthereumLog = Offences;
     type WeightInfo = pallet_ethereum_events::default_weights::SubstrateWeight<Runtime>;
-    type EthereumEventsFilter = EthBridgeTestRuntimeEventsFilter;
+    type ProcessedEventsHandler = AllEventsFilter;
     type ProcessedEventsChecker = EthBridge;
 }
 
@@ -711,7 +691,7 @@ impl pallet_eth_bridge::Config for Runtime {
     type TimeProvider = pallet_timestamp::Pallet<Runtime>;
     type WeightInfo = pallet_eth_bridge::default_weights::SubstrateWeight<Runtime>;
     type BridgeInterfaceNotification = (Summary, TokenManager, NftManager, ParachainStaking);
-    type EthereumEventsFilter = EthBridgeTestRuntimeEventsFilter;
+    type ProcessedEventsHandler = NoEventsFilter;
 }
 
 // Other pallets


### PR DESCRIPTION
## Proposed changes

- Refactors the trait name for filter handlers and simplifies filter creation.
- Adds sample filters used by runtimes.
- Updates EthereumEvents to consider event types specified in the filter rather than the remaining ones.
- Enables all core events on EthBridge.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

