### PR TITLE
fix: update default AuthorityId in AVN pallet

### DIFF
--- a/pallets/authors-manager/src/mock.rs
+++ b/pallets/authors-manager/src/mock.rs
@@ -157,9 +157,9 @@ impl system::Config for TestRuntime {
 
 #[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
 impl avn::Config for TestRuntime {
+    type AuthorityId = UintAuthorityId;
     type EthereumPublicKeyChecker = Self;
     type NewSessionHandler = AuthorsManager;
-    type DisabledValidatorChecker = ();
 }
 
 parameter_types! {

--- a/pallets/avn-anchor/src/mock.rs
+++ b/pallets/avn-anchor/src/mock.rs
@@ -370,11 +370,11 @@ impl ProvableProxy<RuntimeCall, Signature, AccountId> for TestAvnProxyConfig {
             RuntimeCall::AvnAnchor(avn_anchor::Call::signed_register_chain_handler {
                 proof,
                 ..
-            })
-            | RuntimeCall::AvnAnchor(avn_anchor::Call::signed_update_chain_handler {
+            }) |
+            RuntimeCall::AvnAnchor(avn_anchor::Call::signed_update_chain_handler {
                 proof, ..
-            })
-            | RuntimeCall::AvnAnchor(avn_anchor::Call::signed_submit_checkpoint_with_identity {
+            }) |
+            RuntimeCall::AvnAnchor(avn_anchor::Call::signed_submit_checkpoint_with_identity {
                 proof,
                 ..
             }) => Some(proof.clone()),
@@ -418,8 +418,8 @@ pub fn proxy_event_emitted(
     call_hash: <TestRuntime as system::Config>::Hash,
 ) -> bool {
     System::events().iter().any(|a| {
-        a.event
-            == RuntimeEvent::AvnProxy(avn_proxy::Event::<TestRuntime>::CallDispatched {
+        a.event ==
+            RuntimeEvent::AvnProxy(avn_proxy::Event::<TestRuntime>::CallDispatched {
                 relayer,
                 hash: call_hash,
             })

--- a/pallets/avn-offence-handler/src/mock.rs
+++ b/pallets/avn-offence-handler/src/mock.rs
@@ -28,7 +28,9 @@ frame_support::construct_runtime!(
 pub type ValidatorId = <TestRuntime as session::Config>::ValidatorId;
 
 #[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
-impl pallet_avn::Config for TestRuntime {}
+impl pallet_avn::Config for TestRuntime {
+    type AuthorityId = UintAuthorityId;
+}
 
 parameter_types! {
     pub const BlockHashCount: u64 = 250;

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -132,13 +132,9 @@ impl pallet_nft_manager::Config for TestRuntime {
     type BatchBound = ConstU32<10>;
 }
 
+#[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
 impl pallet_avn::Config for TestRuntime {
-    type RuntimeEvent = RuntimeEvent;
     type AuthorityId = UintAuthorityId;
-    type EthereumPublicKeyChecker = ();
-    type NewSessionHandler = ();
-    type DisabledValidatorChecker = ();
-    type WeightInfo = ();
 }
 
 parameter_types! {

--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -124,7 +124,6 @@ pub mod pallet {
     pub mod config_preludes {
         use super::*;
         use frame_support::derive_impl;
-        use sp_runtime::testing::UintAuthorityId;
         pub struct TestDefaultConfig;
 
         #[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig, no_aggregated_types)]
@@ -134,7 +133,7 @@ pub mod pallet {
         impl DefaultConfig for TestDefaultConfig {
             #[inject_runtime_type]
             type RuntimeEvent = ();
-            type AuthorityId = UintAuthorityId;
+            type AuthorityId = sp_application_crypto::sr25519::AppPublic;
             type EthereumPublicKeyChecker = ();
             type NewSessionHandler = ();
             type DisabledValidatorChecker = ();

--- a/pallets/avn/src/mock.rs
+++ b/pallets/avn/src/mock.rs
@@ -31,7 +31,9 @@ frame_support::construct_runtime!(
 );
 
 #[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
-impl Config for TestRuntime {}
+impl Config for TestRuntime {
+    type AuthorityId = UintAuthorityId;
+}
 
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl system::Config for TestRuntime {

--- a/pallets/eth-bridge/src/tests/mock.rs
+++ b/pallets/eth-bridge/src/tests/mock.rs
@@ -114,7 +114,9 @@ impl system::Config for TestRuntime {
 #[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
 impl avn::Config for TestRuntime {
     type EthereumPublicKeyChecker = Self;
+    type AuthorityId = UintAuthorityId;
 }
+
 impl pallet_timestamp::Config for TestRuntime {
     type Moment = u64;
     type OnTimestampSet = ();

--- a/pallets/ethereum-events/src/mock.rs
+++ b/pallets/ethereum-events/src/mock.rs
@@ -171,7 +171,9 @@ thread_local! {
 }
 
 #[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
-impl avn::Config for TestRuntime {}
+impl avn::Config for TestRuntime {
+    type AuthorityId = UintAuthorityId;
+}
 pub struct TestSessionManager;
 impl session::SessionManager<AccountId> for TestSessionManager {
     fn new_session(_new_index: SessionIndex) -> Option<Vec<AccountId>> {

--- a/pallets/nft-manager/src/tests/mock.rs
+++ b/pallets/nft-manager/src/tests/mock.rs
@@ -71,10 +71,7 @@ impl system::Config for TestRuntime {
 }
 
 #[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
-impl avn::Config for TestRuntime {
-    type EthereumPublicKeyChecker = ();
-    type AuthorityId = avn::sr25519::AuthorityId;
-}
+impl avn::Config for TestRuntime {}
 
 pub struct ExtBuilder {
     storage: sp_runtime::Storage,

--- a/pallets/summary/src/tests/mock.rs
+++ b/pallets/summary/src/tests/mock.rs
@@ -422,7 +422,9 @@ impl system::Config for TestRuntime {
 }
 
 #[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
-impl avn::Config for TestRuntime {}
+impl avn::Config for TestRuntime {
+    type AuthorityId = UintAuthorityId;
+}
 
 impl pallet_eth_bridge::Config for TestRuntime {
     type MaxQueuedTxRequests = frame_support::traits::ConstU32<100>;

--- a/pallets/token-manager/src/mock.rs
+++ b/pallets/token-manager/src/mock.rs
@@ -184,7 +184,6 @@ impl system::Config for TestRuntime {
 
 #[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
 impl avn::Config for TestRuntime {
-    type EthereumPublicKeyChecker = ();
     type AuthorityId = UintAuthorityId;
 }
 

--- a/pallets/validators-manager/src/tests/mock.rs
+++ b/pallets/validators-manager/src/tests/mock.rs
@@ -173,6 +173,7 @@ impl system::Config for TestRuntime {
 
 #[derive_impl(pallet_avn::config_preludes::TestDefaultConfig as pallet_avn::DefaultConfig)]
 impl avn::Config for TestRuntime {
+    type AuthorityId = UintAuthorityId;
     type EthereumPublicKeyChecker = Self;
     type NewSessionHandler = ValidatorManager;
     type DisabledValidatorChecker = ValidatorManager;


### PR DESCRIPTION
## Proposed changes

The UintAuthorityId mock is not suitable as the default for the test implementation because it's not available in non-test configurations, which the default implementation relies on.

This commit sets the default AuthorityId to sr25519. Mocks explicitly restore UintAuthorityId where needed.

