### PR TITLE
feat: Updates client to use polkadot-sdk 1.6 libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,7 @@ dependencies = [
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "secp256k1 0.21.3",
- "secp256k1 0.24.3",
+ "secp256k1 0.28.0",
  "serde",
  "serde_json",
  "sp-api",
@@ -12578,15 +12578,6 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
-dependencies = [
- "secp256k1-sys 0.6.1",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
@@ -12599,15 +12590,6 @@ name = "secp256k1-sys"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
 dependencies = [
  "cc",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,14 +16,15 @@ name = "avn-parachain-collator"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.4.2", features = ["derive"] }
+clap = { version = "4.4.14", features = ["derive"] }
 log = "0.4.20"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-serde = { version = "1.0.163", features = ["derive"] }
+serde = { version = "1.0.195", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 hex-literal = "0.4.1"
 hex = "0.4"
-serde_json = "1.0.85"
+serde_json = { version = "1.0.111" }
+
 futures = "0.3.21"
 cfg-if = "0.1"
 
@@ -111,6 +112,7 @@ substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-s
 [features]
 default = ["avn-native-runtime"]
 runtime-benchmarks = [
+    "cumulus-primitives-core/runtime-benchmarks",
     "frame-benchmarking-cli/runtime-benchmarks",
     "frame-benchmarking/runtime-benchmarks",
     "polkadot-cli/runtime-benchmarks",

--- a/node/avn-lower-rpc/Cargo.toml
+++ b/node/avn-lower-rpc/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.21"
 log = "0.4.20"
 parking_lot = "0.12.1"
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.163", features = ["derive"], default-features = false}
+serde = { version = "1.0.195", features = ["derive"], default-features = false}
 serde_json = "1.0.85"
 thiserror = "1.0"
 hex = "0.4"

--- a/node/avn-service/Cargo.toml
+++ b/node/avn-service/Cargo.toml
@@ -29,7 +29,8 @@ jsonrpc-core = "18.0.0"
 tokio = { version = "1.19", features = ["sync"] }
 
 hex = "0.4"
-secp256k1 = { version = "0.24.0", default-features = false, features = [
+# Ensure compatibility by matching sp-core's secp256k1 version. Let cargo handle exact version matching.
+secp256k1 = { version = ">0.26.0", default-features = false, features = [
     "recovery",
     "alloc",
 ] }

--- a/node/avn-service/src/lib.rs
+++ b/node/avn-service/src/lib.rs
@@ -436,7 +436,7 @@ where
             let my_priv_key = get_priv_key(keystore_path, &my_eth_address)?;
 
             let secret = SecretKey::from_slice(&my_priv_key)?;
-            let message = secp256k1::Message::from_slice(&hashed_message)?;
+            let message = secp256k1::Message::from_digest_slice(&hashed_message)?;
             let signature: Signature = secp.sign_ecdsa_recoverable(&message, &secret).into();
 
             Ok(hex::encode(signature.encode()))

--- a/node/src/chain_spec/stable/local.rs
+++ b/node/src/chain_spec/stable/local.rs
@@ -2,6 +2,8 @@ use crate::chain_spec::{
     avn_chain_properties, constants::*, ChainSpec, ChainType, EthPublicKey, Extensions,
 };
 
+use avn_parachain_runtime::{self as avn_runtime};
+
 use crate::chain_spec::stable::{
     get_account_id_from_seed, get_account_id_from_seed_no_derivation, get_authority_keys_from_seed,
     testnet_genesis,
@@ -77,6 +79,7 @@ pub fn development_config() -> ChainSpec {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
             para_id: dev_rococo_parachain_id,
         },
+        avn_runtime::WASM_BINARY.expect("WASM binary was not build, please build it!"),
     )
 }
 
@@ -155,6 +158,7 @@ pub fn local_testnet_config() -> ChainSpec {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
             para_id: 2000,
         },
+        avn_runtime::WASM_BINARY.expect("WASM binary was not build, please build it!"),
     )
 }
 

--- a/node/src/chain_spec/stable/mod.rs
+++ b/node/src/chain_spec/stable/mod.rs
@@ -59,12 +59,6 @@ pub(crate) fn testnet_genesis(
             _phantom: Default::default(),
             bridge_contract_address: avn_eth_contract.clone(),
         },
-        system: avn_runtime::SystemConfig {
-            code: avn_runtime::WASM_BINARY
-                .expect("WASM binary was not build, please build it!")
-                .to_vec(),
-            ..Default::default()
-        },
         balances: avn_runtime::BalancesConfig {
             balances: endowed_accounts.iter().cloned().map(|(k, a)| (k, a)).collect(),
         },
@@ -85,7 +79,6 @@ pub(crate) fn testnet_genesis(
         },
         // no need to pass anything to aura, in fact it will panic if we do. Session will take care
         // of this.
-        assets: Default::default(),
         eth_bridge: EthBridgeConfig {
             _phantom: Default::default(),
             eth_tx_lifetime_secs: 60 * 30 as u64, // 30 minutes
@@ -107,11 +100,7 @@ pub(crate) fn testnet_genesis(
                 .collect::<Vec<_>>(),
         },
         authority_discovery: AuthorityDiscoveryConfig { keys: vec![], ..Default::default() },
-        aura: Default::default(),
-        aura_ext: Default::default(),
         im_online: ImOnlineConfig { keys: vec![] },
-        nft_manager: Default::default(),
-        parachain_system: Default::default(),
         parachain_staking: ParachainStakingConfig {
             candidates: candidates
                 .iter()
@@ -149,5 +138,6 @@ pub(crate) fn testnet_genesis(
                 }
             },
         },
+        ..Default::default()
     }
 }

--- a/node/src/chain_spec/stable/staging.rs
+++ b/node/src/chain_spec/stable/staging.rs
@@ -3,6 +3,8 @@ use crate::chain_spec::{
     EthPublicKey, Extensions, ImOnlineId,
 };
 
+use avn_parachain_runtime::{self as avn_runtime};
+
 use crate::chain_spec::stable::{
     get_account_id_from_seed, get_authority_keys_from_seed_with_derivation, testnet_genesis,
 };
@@ -77,6 +79,7 @@ pub fn staging_testnet_config() -> ChainSpec {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
             para_id: staging_parachain_id,
         },
+        avn_runtime::WASM_BINARY.expect("WASM binary was not build, please build it!"),
     )
 }
 
@@ -137,6 +140,7 @@ pub fn staging_dev_testnet_config() -> ChainSpec {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
             para_id: staging_parachain_id,
         },
+        avn_runtime::WASM_BINARY.expect("WASM binary was not build, please build it!"),
     )
 }
 

--- a/node/src/chain_spec/test/local.rs
+++ b/node/src/chain_spec/test/local.rs
@@ -1,6 +1,7 @@
 use crate::chain_spec::{
     avn_chain_properties, constants::*, helpers::*, ChainType, EthPublicKey, Extensions,
 };
+use avn_test_runtime::{self as avn_test_runtime};
 
 use crate::chain_spec::test::{avn_test_runtime_genesis, get_account_id_from_seed, ChainSpec};
 use hex_literal::hex;
@@ -72,6 +73,7 @@ pub fn avn_garde_local_config() -> ChainSpec {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
             para_id: 2000,
         },
+        avn_test_runtime::WASM_BINARY.expect("WASM binary was not build, please build it!"),
     )
 }
 

--- a/node/src/chain_spec/test/mod.rs
+++ b/node/src/chain_spec/test/mod.rs
@@ -58,12 +58,6 @@ pub(crate) fn avn_test_runtime_genesis(
             _phantom: Default::default(),
             bridge_contract_address: avn_eth_contract.clone(),
         },
-        system: avn_test_runtime::SystemConfig {
-            code: avn_test_runtime::WASM_BINARY
-                .expect("WASM binary was not build, please build it!")
-                .to_vec(),
-            ..Default::default()
-        },
         balances: avn_test_runtime::BalancesConfig {
             balances: endowed_accounts.iter().cloned().map(|(k, a)| (k, a)).collect(),
         },
@@ -109,11 +103,7 @@ pub(crate) fn avn_test_runtime_genesis(
                 .collect::<Vec<_>>(),
         },
         authority_discovery: AuthorityDiscoveryConfig { keys: vec![], ..Default::default() },
-        aura: Default::default(),
-        aura_ext: Default::default(),
         im_online: ImOnlineConfig { keys: vec![] },
-        nft_manager: Default::default(),
-        parachain_system: Default::default(),
         parachain_staking: ParachainStakingConfig {
             candidates: candidates
                 .iter()
@@ -130,7 +120,7 @@ pub(crate) fn avn_test_runtime_genesis(
             ..Default::default()
         },
         sudo: SudoConfig { key: Some(sudo_account) },
-        summary: SummaryConfig { schedule_period, voting_period },
+        summary: SummaryConfig { schedule_period, voting_period, _phantom: Default::default() },
         anchor_summary: AnchorSummaryConfig {
             schedule_period,
             voting_period,
@@ -145,6 +135,8 @@ pub(crate) fn avn_test_runtime_genesis(
             avt_token_contract,
             lower_schedule_period: 10,
             balances: vec![],
+            ..Default::default()
         },
+        ..Default::default()
     }
 }

--- a/node/src/chain_spec/test/staging.rs
+++ b/node/src/chain_spec/test/staging.rs
@@ -1,6 +1,7 @@
 use crate::chain_spec::{
     avn_chain_properties, constants::*, helpers::*, ChainType, EthPublicKey, Extensions,
 };
+use avn_test_runtime::{self as avn_test_runtime};
 
 use crate::chain_spec::test::{avn_test_runtime_genesis, get_account_id_from_seed, ChainSpec};
 use hex_literal::hex;
@@ -72,6 +73,7 @@ pub fn avn_garde_staging_config() -> ChainSpec {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
             para_id: avn_garde_staging_parachain_id,
         },
+        avn_test_runtime::WASM_BINARY.expect("WASM binary was not build, please build it!"),
     )
 }
 

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -28,8 +28,11 @@ pub enum Subcommand {
     /// Remove the whole chain.
     PurgeChain(cumulus_client_cli::PurgeChainCmd),
 
-    /// Export the genesis state of the parachain.
-    ExportGenesisState(cumulus_client_cli::ExportGenesisStateCommand),
+    /// Export the genesis head data of the parachain.
+    ///
+    /// Head data is the encoded block header.
+    #[command(alias = "export-genesis-state")]
+    ExportGenesisHead(cumulus_client_cli::ExportGenesisHeadCommand),
 
     /// Export the genesis wasm of the parachain.
     ExportGenesisWasm(cumulus_client_cli::ExportGenesisWasmCommand),

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -167,12 +167,12 @@ pub fn run() -> Result<()> {
                 cmd.run(config, polkadot_config)
             })
         },
-        Some(Subcommand::ExportGenesisState(cmd)) => {
+        Some(Subcommand::ExportGenesisHead(cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.sync_run(|config| {
                 let partials = new_partial::<RuntimeApi>(&config)?;
 
-                cmd.run(&*config.chain_spec, &*partials.client)
+                cmd.run(partials.client)
             })
         },
         Some(Subcommand::ExportGenesisWasm(cmd)) => {


### PR DESCRIPTION
## Proposed changes

Updates the client to be compliant with polkadot-1.6 libraries.

The client still uses the deprecated way of generating chain specs. This is due to the new way using a JSON object for genesis state creation, uses serde-json to serialise the chainspec object with `arbitrary_precision` feature for u128 integer representations and ERC20 denominations.

This PR is mutually exclusive of #453
