### PR TITLE
fix/eth bridge discovered event partition order

### DIFF
--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -750,7 +750,7 @@ pub mod pallet {
                     Self::deposit_event(Event::<T>::AdditionalEventQueued { transaction_hash });
                 },
                 AdminSettings::RestartEventDiscoveryOnRange => {
-                    let _ = EthereumEvents::<T>::clear(10, None);
+                    let _ = EthereumEvents::<T>::clear(100, None);
                 },
             }
 

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -749,6 +749,9 @@ pub mod pallet {
                     .map_err(|_| Error::<T>::QuotaReachedForAdditionalEvents)?;
                     Self::deposit_event(Event::<T>::AdditionalEventQueued { transaction_hash });
                 },
+                AdminSettings::RestartEventDiscoveryOnRange => {
+                    let _ = EthereumEvents::<T>::clear(10, None);
+                },
             }
 
             Ok(().into())

--- a/pallets/eth-bridge/src/tests/incoming_events_tests.rs
+++ b/pallets/eth-bridge/src/tests/incoming_events_tests.rs
@@ -115,7 +115,7 @@ pub fn create_mock_event_partition(
 }
 
 // Added this function as in event_listener_tests to initialize the active event range
-fn init_active_range() {
+pub(crate) fn init_active_range() {
     ActiveEthereumRange::<TestRuntime>::put(ActiveEthRange {
         range: EthBlockRange { start_block: 1, length: 1000 },
         partition: 0,

--- a/pallets/eth-bridge/src/types.rs
+++ b/pallets/eth-bridge/src/types.rs
@@ -153,4 +153,6 @@ pub enum AdminSettings {
     RemoveActiveRequest,
     /// Queue an additional ethereum event to be included in the next range
     QueueAdditionalEthereumEvent(EthTransactionId),
+    /// Removes all votes on Ethereum Events partitions for the active range.
+    RestartEventDiscoveryOnRange,
 }

--- a/primitives/avn-common/src/event_discovery.rs
+++ b/primitives/avn-common/src/event_discovery.rs
@@ -1,9 +1,6 @@
 use core::cmp::Ordering;
 
-use crate::{
-    event_types::{EthEventId, EthTransactionId},
-    *,
-};
+use crate::{event_types::EthTransactionId, *};
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use event_types::EthEvent;

--- a/primitives/avn-common/src/event_discovery.rs
+++ b/primitives/avn-common/src/event_discovery.rs
@@ -1,4 +1,9 @@
-use crate::{event_types::EthTransactionId, *};
+use core::cmp::Ordering;
+
+use crate::{
+    event_types::{EthEventId, EthTransactionId},
+    *,
+};
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use event_types::EthEvent;
@@ -41,34 +46,18 @@ pub struct DiscoveredEvent {
 }
 
 impl PartialOrd for DiscoveredEvent {
-    fn partial_cmp(&self, other: &Self) -> Option<scale_info::prelude::cmp::Ordering> {
-        let ord_sig = self.event.event_id.signature.partial_cmp(&other.event.event_id.signature);
-
-        if let Some(core::cmp::Ordering::Equal) = ord_sig {
-            return ord_sig
-        }
-
-        match self.block.partial_cmp(&other.block) {
-            Some(core::cmp::Ordering::Equal) => {},
-            ord => return ord,
-        }
-        ord_sig
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for DiscoveredEvent {
-    fn cmp(&self, other: &Self) -> scale_info::prelude::cmp::Ordering {
-        let ord_sig = self.event.event_id.signature.cmp(&other.event.event_id.signature);
-
-        if let core::cmp::Ordering::Equal = ord_sig {
-            return ord_sig
-        }
-
+    fn cmp(&self, other: &Self) -> Ordering {
         match self.block.cmp(&other.block) {
-            core::cmp::Ordering::Equal => {},
-            ord => return ord,
+            Ordering::Equal =>
+                self.event.event_id.transaction_hash.cmp(&other.event.event_id.transaction_hash),
+            ord => ord,
         }
-        ord_sig
     }
 }
 
@@ -267,26 +256,4 @@ pub mod events_helpers {
         let rem = calculation_block.checked_rem(range_length).ok_or(())?;
         Ok(calculation_block.saturating_sub(rem))
     }
-}
-
-#[test]
-pub fn event_id_comparison_is_case_insensitive() {
-    use event_types::EthEventId;
-    use hex_literal::hex;
-
-    let left = EthEventId {
-        signature: H256(hex!("000000000000000000000000000000000000000000000000000000000000dddd")),
-        transaction_hash: H256(hex!(
-            "000000000000000000000000000000000000000000000000000000000000eeee"
-        )),
-    };
-
-    let right = EthEventId {
-        signature: H256(hex!("000000000000000000000000000000000000000000000000000000000000DDDD")),
-        transaction_hash: H256(hex!(
-            "000000000000000000000000000000000000000000000000000000000000EEEE"
-        )),
-    };
-
-    assert_eq!(left, right);
 }

--- a/primitives/avn-common/src/lib.rs
+++ b/primitives/avn-common/src/lib.rs
@@ -31,6 +31,9 @@ pub mod eth_key_actions;
 pub mod event_discovery;
 pub mod event_types;
 pub mod ocw_lock;
+#[cfg(test)]
+#[path = "tests/test_event_discovery.rs"]
+pub mod test_event_discovery;
 
 /// Ingress counter type for a counter that can sign the same message with a different signature
 /// each time

--- a/primitives/avn-common/src/tests/test_event_discovery.rs
+++ b/primitives/avn-common/src/tests/test_event_discovery.rs
@@ -1,0 +1,120 @@
+#[cfg(test)]
+use crate::event_types::{EventData, LiftedData, ValidEvents};
+use crate::{
+    event_discovery::{
+        events_helpers::EthereumEventsPartitionFactory, DiscoveredEvent, EthBlockRange,
+    },
+    event_types::{EthEvent, EthEventId},
+};
+use hex_literal::hex;
+use sp_core::{H160, H256, U256};
+
+#[test]
+pub fn event_id_comparison_is_case_insensitive() {
+    let left = EthEventId {
+        signature: H256(hex!("000000000000000000000000000000000000000000000000000000000000dddd")),
+        transaction_hash: H256(hex!(
+            "000000000000000000000000000000000000000000000000000000000000eeee"
+        )),
+    };
+
+    let right = EthEventId {
+        signature: H256(hex!("000000000000000000000000000000000000000000000000000000000000DDDD")),
+        transaction_hash: H256(hex!(
+            "000000000000000000000000000000000000000000000000000000000000EEEE"
+        )),
+    };
+
+    assert_eq!(left, right);
+}
+
+#[test]
+pub fn discovered_event_ordering_works() {
+    let mock_event_data = EventData::LogLifted(LiftedData {
+        token_contract: H160::zero(),
+        sender_address: H160::zero(),
+        receiver_address: H256::zero(),
+        amount: 1,
+        nonce: U256::zero(),
+    });
+    let first_event_set = vec![
+        DiscoveredEvent {
+            event: EthEvent {
+                event_id: EthEventId {
+                    signature: ValidEvents::Lifted.signature(),
+                    transaction_hash: H256(hex!(
+                        "000000000000000000000000000000000000000000000000000000000000aaaa"
+                    )),
+                },
+                event_data: mock_event_data.clone(),
+            },
+            block: 1,
+        },
+        DiscoveredEvent {
+            event: EthEvent {
+                event_id: EthEventId {
+                    signature: ValidEvents::Lifted.signature(),
+                    transaction_hash: H256(hex!(
+                        "000000000000000000000000000000000000000000000000000000000000bbbb"
+                    )),
+                },
+                event_data: mock_event_data.clone(),
+            },
+            block: 1,
+        },
+        DiscoveredEvent {
+            event: EthEvent {
+                event_id: EthEventId {
+                    signature: ValidEvents::Lifted.signature(),
+                    transaction_hash: H256(hex!(
+                        "000000000000000000000000000000000000000000000000000000000000cccc"
+                    )),
+                },
+                event_data: mock_event_data.clone(),
+            },
+            block: 1,
+        },
+        DiscoveredEvent {
+            event: EthEvent {
+                event_id: EthEventId {
+                    signature: ValidEvents::Lifted.signature(),
+                    transaction_hash: H256(hex!(
+                        "000000000000000000000000000000000000000000000000000000000000dddd"
+                    )),
+                },
+                event_data: mock_event_data.clone(),
+            },
+            block: 1,
+        },
+        DiscoveredEvent {
+            event: EthEvent {
+                event_id: EthEventId {
+                    signature: ValidEvents::Lifted.signature(),
+                    transaction_hash: H256(hex!(
+                        "000000000000000000000000000000000000000000000000000000000000eeee"
+                    )),
+                },
+                event_data: mock_event_data.clone(),
+            },
+            block: 1,
+        },
+    ];
+
+    let second_event_set = vec![
+        first_event_set[4].clone(),
+        first_event_set[3].clone(),
+        first_event_set[2].clone(),
+        first_event_set[1].clone(),
+        first_event_set[0].clone(),
+    ];
+
+    let range = EthBlockRange { start_block: 1, length: 10 };
+    assert_eq!(
+        EthereumEventsPartitionFactory::create_partitions(range.clone(), first_event_set)
+            .first()
+            .unwrap(),
+        EthereumEventsPartitionFactory::create_partitions(range.clone(), second_event_set)
+            .first()
+            .unwrap()
+    );
+}


### PR DESCRIPTION
## Proposed changes

Fixes an issue in the Ord implementation of DiscoveredEvent where event
ordering was based on the event signature instead of the transaction hash.
This caused inconsistent partitioning of the same dataset due to unstable
or incorrect ordering.

Ordering is now based on block number and transaction hash to guarantee
uniqueness and determinism.

Extends the set_admin_setting extrinsic to provide the option to reset
the vote data for ethereum events range.

Jira ticket:
- SYS-4548

This pr ports the work from https://github.com/AventusProtocolFoundation/avn-parachain/pull/507

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->
