### PR TITLE
fix: Remove manual rust installation step

### DIFF
--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -38,16 +38,6 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2023-05-22
-          components: rustfmt, clippy
-          target: wasm32-unknown-unknown
-          override: true
-          default: true
-
       - name: Restore cargo cache - common
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cargo-check.yml
+++ b/.github/workflows/cargo-check.yml
@@ -33,16 +33,6 @@ jobs:
           ref: ${{ inputs.ref }}
           repository: ${{ inputs.repository }}
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2023-05-22
-          components: rustfmt, clippy
-          target: wasm32-unknown-unknown
-          override: true
-          default: true
-
       - name: Restore cargo cache - common
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -69,16 +69,6 @@ jobs:
           ref: ${{ inputs.ref }}
           repository: ${{ inputs.repository }}
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2023-05-22
-          components: rustfmt, clippy
-          target: wasm32-unknown-unknown
-          override: true
-          default: true
-
       - name: Restore cargo cache - common
         uses: actions/cache@v3
         with:
@@ -110,16 +100,6 @@ jobs:
           fetch-depth: ${{ inputs.fetch-depth }}
           ref: ${{ inputs.ref }}
           repository: ${{ inputs.repository }}
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2023-05-22
-          components: rustfmt, clippy
-          target: wasm32-unknown-unknown
-          override: true
-          default: true
 
       - name: Restore cargo cache - common
         uses: actions/cache@v3


### PR DESCRIPTION
## Proposed changes

Rust version should be mandated from rust-toolchain file for build operations.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

