### PR TITLE
Restores the rust installation step

### DIFF
--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -38,8 +38,15 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
 
-      - name: Install build target
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.81.0
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+          override: true
+          default: true
 
       - name: Restore cargo cache - common
         uses: actions/cache@v3

--- a/.github/workflows/cargo-check.yml
+++ b/.github/workflows/cargo-check.yml
@@ -33,8 +33,15 @@ jobs:
           ref: ${{ inputs.ref }}
           repository: ${{ inputs.repository }}
 
-      - name: Install build target
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.81.0
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+          override: true
+          default: true
 
       - name: Restore cargo cache - common
         uses: actions/cache@v3

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -69,8 +69,16 @@ jobs:
           ref: ${{ inputs.ref }}
           repository: ${{ inputs.repository }}
 
-      - name: Install build target
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.81.0
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+          override: true
+          default: true
+
 
       - name: Restore cargo cache - common
         uses: actions/cache@v3
@@ -104,8 +112,16 @@ jobs:
           ref: ${{ inputs.ref }}
           repository: ${{ inputs.repository }}
 
-      - name: Install build target
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.81.0
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+          override: true
+          default: true
+
 
       - name: Restore cargo cache - common
         uses: actions/cache@v3


### PR DESCRIPTION

## Proposed changes

To address building errors, rustup is not installed on the builders, leading to compilation errors.
Uses version 1.81.0 of rust onwards

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

