### PR TITLE
Allow changing origin in runtime

### DIFF
--- a/pallets/avn-transaction-payment/src/lib.rs
+++ b/pallets/avn-transaction-payment/src/lib.rs
@@ -51,6 +51,9 @@ pub mod pallet {
         /// Currency type for processing fee payment
         type Currency: Currency<Self::AccountId>;
 
+        /// The origin that is allowed to set the known senders
+        type KnownUserOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
         type WeightInfo: WeightInfo;
     }
 
@@ -104,7 +107,7 @@ pub mod pallet {
             known_sender: T::AccountId,
             config: AdjustmentInput<T>,
         ) -> DispatchResult {
-            frame_system::ensure_root(origin)?;
+            T::KnownUserOrigin::ensure_origin(origin)?;
 
             let mut fee_adjustment_config: FeeAdjustmentConfig<T> = Default::default();
             if config.adjustment_type != AdjustmentType::None {
@@ -162,7 +165,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             known_sender: T::AccountId,
         ) -> DispatchResult {
-            frame_system::ensure_root(origin)?;
+            T::KnownUserOrigin::ensure_origin(origin)?;
 
             ensure!(
                 <KnownSenders<T>>::contains_key(&known_sender) == true,

--- a/pallets/avn-transaction-payment/src/tests/mock.rs
+++ b/pallets/avn-transaction-payment/src/tests/mock.rs
@@ -3,6 +3,7 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use frame_support::{
+    ord_parameter_types,
     pallet_prelude::DispatchClass,
     parameter_types,
     traits::{ConstU16, ConstU64, ConstU8, Imbalance, OnFinalize, OnInitialize, OnUnbalanced},
@@ -36,6 +37,14 @@ frame_support::construct_runtime!(
         AvnTransactionPayment: pallet_avn_transaction_payment::{Pallet, Call, Storage, Event<T>}
     }
 );
+
+fn sudo() -> AccountId {
+    return TestAccount::new(101).account_id()
+}
+
+ord_parameter_types! {
+    pub const Sudo: AccountId = sudo();
+}
 
 parameter_types! {
     pub BlockLength: limits::BlockLength = limits::BlockLength::max_with_normal_ratio(1024, NORMAL_DISPATCH_RATIO);
@@ -87,6 +96,7 @@ impl pallet_avn_transaction_payment::Config for TestRuntime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type Currency = Balances;
+    type KnownUserOrigin = frame_system::EnsureRoot<AccountId>;
     type WeightInfo = pallet_avn_transaction_payment::default_weights::SubstrateWeight<TestRuntime>;
 }
 

--- a/pallets/avn-transaction-payment/src/tests/mock.rs
+++ b/pallets/avn-transaction-payment/src/tests/mock.rs
@@ -38,14 +38,6 @@ frame_support::construct_runtime!(
     }
 );
 
-fn sudo() -> AccountId {
-    return TestAccount::new(101).account_id()
-}
-
-ord_parameter_types! {
-    pub const Sudo: AccountId = sudo();
-}
-
 parameter_types! {
     pub BlockLength: limits::BlockLength = limits::BlockLength::max_with_normal_ratio(1024, NORMAL_DISPATCH_RATIO);
     pub RuntimeBlockWeights: limits::BlockWeights = limits::BlockWeights::builder()

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -637,6 +637,7 @@ impl pallet_avn_transaction_payment::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type Currency = Balances;
+    type KnownUserOrigin = EnsureRoot<AccountId>;
     type WeightInfo = pallet_avn_transaction_payment::default_weights::SubstrateWeight<Runtime>;
 }
 


### PR DESCRIPTION
## Proposed changes

This PR allows changing the origin for managing `known senders` in the runtime instead of hard coding it in the pallet.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [x] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
