### PR TITLE
fix(system-tx): Enhance validation of system transactions

### DIFF
--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -978,6 +978,8 @@ pub mod pallet {
         type Call = Call<T>;
         // Confirm that the call comes from an author before it can enter the pool:
         fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
+            let reduce_priority: TransactionPriority = TransactionPriority::from(1000u64);
+
             match call {
                 Call::add_confirmation { request_id, confirmation, author, signature } =>
                     if AVN::<T>::signature_is_valid(
@@ -987,7 +989,9 @@ pub mod pallet {
                     ) {
                         ValidTransaction::with_tag_prefix("EthBridgeAddConfirmation")
                             .and_provides((call, request_id))
-                            .priority(TransactionPriority::max_value())
+                            .priority(TransactionPriority::max_value() - reduce_priority)
+                            .longevity(64_u64)
+                            .propagate(true)
                             .build()
                     } else {
                         InvalidTransaction::Custom(1u8).into()
@@ -1000,7 +1004,9 @@ pub mod pallet {
                     ) {
                         ValidTransaction::with_tag_prefix("EthBridgeAddReceipt")
                             .and_provides((call, tx_id))
-                            .priority(TransactionPriority::max_value())
+                            .priority(TransactionPriority::max_value() - reduce_priority)
+                            .longevity(64_u64)
+                            .propagate(true)
                             .build()
                     } else {
                         InvalidTransaction::Custom(2u8).into()
@@ -1025,33 +1031,42 @@ pub mod pallet {
                     ) {
                         ValidTransaction::with_tag_prefix("EthBridgeAddCorroboration")
                             .and_provides((call, tx_id))
-                            .priority(TransactionPriority::max_value())
+                            .priority(TransactionPriority::max_value() - reduce_priority)
+                            .longevity(64_u64)
+                            .propagate(true)
                             .build()
                     } else {
                         InvalidTransaction::Custom(3u8).into()
                     },
                 Call::submit_ethereum_events { author, events_partition, signature } =>
-                    if AVN::<T>::signature_is_valid(
-                        &(
-                            &SUBMIT_ETHEREUM_EVENTS_HASH_CONTEXT,
-                            &author.account_id,
-                            events_partition,
-                        ),
-                        &author,
-                        signature,
-                    ) {
+                    if Self::does_range_matches_active(&events_partition) &&
+                        AVN::<T>::signature_is_valid(
+                            &(
+                                &SUBMIT_ETHEREUM_EVENTS_HASH_CONTEXT,
+                                &author.account_id,
+                                events_partition,
+                            ),
+                            &author,
+                            signature,
+                        )
+                    {
                         ValidTransaction::with_tag_prefix("EthBridgeAddEventRange")
                             .and_provides((
                                 call,
                                 events_partition.range(),
                                 events_partition.partition(),
                             ))
-                            .priority(TransactionPriority::max_value())
+                            .priority(TransactionPriority::max_value() - reduce_priority)
+                            .longevity(64_u64)
+                            .propagate(true)
                             .build()
                     } else {
                         InvalidTransaction::Custom(4u8).into()
                     },
-                Call::submit_latest_ethereum_block { author, latest_seen_block, signature } =>
+                Call::submit_latest_ethereum_block { author, latest_seen_block, signature } => {
+                    if Self::active_ethereum_range().is_some() {
+                        return InvalidTransaction::Custom(5u8).into()
+                    }
                     if AVN::<T>::signature_is_valid(
                         &(&SUBMIT_LATEST_ETH_BLOCK_CONTEXT, &author.account_id, *latest_seen_block),
                         &author,
@@ -1059,11 +1074,14 @@ pub mod pallet {
                     ) {
                         ValidTransaction::with_tag_prefix("EthBridgeAddLatestEthBlock")
                             .and_provides((call, latest_seen_block))
-                            .priority(TransactionPriority::max_value())
+                            .priority(TransactionPriority::max_value() - reduce_priority)
+                            .longevity(64_u64)
+                            .propagate(true)
                             .build()
                     } else {
                         InvalidTransaction::Custom(5u8).into()
-                    },
+                    }
+                },
                 _ => InvalidTransaction::Call.into(),
             }
         }
@@ -1265,6 +1283,17 @@ impl<T: Config> Pallet<T> {
     fn ethereum_event_has_already_been_accepted(tx_hash: &H256) -> bool {
         if let Some(processed_event) = ProcessedEthereumEvents::<T>::get(tx_hash) {
             if processed_event.accepted {
+                return true
+            }
+        }
+        false
+    }
+
+    fn does_range_matches_active(events_partition: &EthereumEventsPartition) -> bool {
+        if let Some(active_range) = Self::active_ethereum_range() {
+            if *events_partition.range() == active_range.range &&
+                events_partition.partition() == active_range.partition
+            {
                 return true
             }
         }


### PR DESCRIPTION
This update refines the validation process for system transactions by:
- Setting transaction longevity to 64 blocks to prevent immortal transactions.
- Slightly reducing transaction priority to allow more urgent system tasks to be prioritized and to enable transaction replacement in the memory pool.
- Extending unsigned transaction validation to ensure transactions fall within the active range.

## Proposed changes

<!---Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.-->

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [x] Patch release <!---i.ex v1.0.0 => v1.0.1-->

