### PR TITLE
feat: upgrade to rust 1.85 stable

### DIFF
--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.81.0
+          toolchain: 1.85.0
           components: rustfmt, clippy
           target: wasm32-unknown-unknown
           override: true

--- a/.github/workflows/cargo-check.yml
+++ b/.github/workflows/cargo-check.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.81.0
+          toolchain: 1.85.0
           components: rustfmt, clippy
           target: wasm32-unknown-unknown
           override: true

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.81.0
+          toolchain: 1.85.0
           components: rustfmt, clippy
           target: wasm32-unknown-unknown
           override: true
@@ -116,7 +116,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.81.0
+          toolchain: 1.85.0
           components: rustfmt, clippy
           target: wasm32-unknown-unknown
           override: true

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -23,7 +23,6 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-edit
-          version: '0.13.1'
       - name: Check if Release
         id: release_type_check
         env:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -27,7 +27,6 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-edit
-          version: '0.13.1'
       - name: Verify PR type
         env:
           description: ${{ github.event.pull_request.body }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.85.0"
 components = [
 	"cargo",
 	"clippy",


### PR DESCRIPTION
## Proposed changes
Upgrades rust to 1.85 to add support for 2024 edition which some of the newer crates depend on.
CI and toolchain files updated.
Removes fixed version of `cargo-edit` which was set due to lack of support to 2024 edition.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

