### PR TITLE
feat: enable support for multiple instances in the client

### DIFF
--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -453,7 +453,7 @@ where
     pub keystore: Arc<LocalKeystore>,
     pub keystore_path: PathBuf,
     pub avn_port: Option<String>,
-    pub eth_node_url: String,
+    pub eth_node_urls: Vec<String>,
     // TODO add support for multiple web3 instances on different chains
     pub web3_data_mutex: Arc<Mutex<Web3Data>>,
     pub client: Arc<ClientT>,
@@ -485,11 +485,14 @@ where
             let web3_init_time = Instant::now();
             log::info!("⛓️  avn-service: web3 initialisation start");
 
-            let web3 = setup_web3_connection(&self.eth_node_url);
+            // TODO fixme
+            let eth_web3_url =
+                self.eth_node_urls.first().cloned().unwrap_or_else(|| "".to_string());
+            let web3 = setup_web3_connection(&eth_web3_url);
             if web3.is_none() {
                 log::error!(
                     "💔 Error creating a web3 connection. URL is not valid {:?}",
-                    &self.eth_node_url
+                    &self.eth_node_urls
                 );
                 return Err(server_error("Error creating a web3 connection".to_string()))
             }

--- a/node/avn-service/src/ethereum_events_handler.rs
+++ b/node/avn-service/src/ethereum_events_handler.rs
@@ -23,7 +23,7 @@ use sp_blockchain::HeaderBackend;
 use sp_core::{sr25519::Public, H256 as SpH256};
 use sp_keystore::Keystore;
 use sp_runtime::SaturatedConversion;
-use std::{collections::HashMap, marker::PhantomData, time::Instant};
+use std::{collections::HashMap, time::Instant};
 pub use std::{path::PathBuf, sync::Arc};
 use tide::Error as TideError;
 use tokio::time::{sleep, Duration};
@@ -36,7 +36,7 @@ use web3::{
 use pallet_eth_bridge::{SUBMIT_ETHEREUM_EVENTS_HASH_CONTEXT, SUBMIT_LATEST_ETH_BLOCK_CONTEXT};
 use pallet_eth_bridge_runtime_api::InstanceId;
 
-use crate::{server_error, setup_web3_connection, Web3Data};
+use crate::{get_chain_id_from_provider, server_error, setup_web3_connection, Web3Data};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 
 pub struct EventInfo {
@@ -454,10 +454,8 @@ where
     pub keystore_path: PathBuf,
     pub avn_port: Option<String>,
     pub eth_node_urls: Vec<String>,
-    // TODO add support for multiple web3 instances on different chains
-    pub web3_data_mutex: Arc<Mutex<Web3Data>>,
+    pub web3_data_mutexes: HashMap<u64, Arc<Mutex<Web3Data>>>,
     pub client: Arc<ClientT>,
-    pub _block: PhantomData<Block>,
     pub offchain_transaction_pool_factory: OffchainTransactionPoolFactory<Block>,
 }
 
@@ -473,35 +471,75 @@ where
         + ApiExt<Block>
         + BlockBuilder<Block>,
 {
-    pub async fn initialise_web3(&self) -> Result<(), TideError> {
-        if let Some(mut web3_data_mutex) = self.web3_data_mutex.try_lock() {
-            if web3_data_mutex.web3.is_some() {
+    pub async fn initialise_web3(
+        &mut self,
+        chain_id: u64,
+    ) -> Result<Arc<Mutex<Web3Data>>, TideError> {
+        let web3_init_time = Instant::now();
+        log::info!("⛓️  avn-events-handler: web3 initialisation start");
+
+        // See if we have an existing web3 data mutex for the chain_id
+        match self.web3_data_mutexes.get(&chain_id) {
+            Some(web3_data_pointer) => {
+                log::debug!("⛓️  Found existing web3 connection for network: {}", chain_id);
+                return Ok(Arc::clone(&web3_data_pointer))
+            },
+            None => log::debug!(
+                "⛓️  No existing web3 connection found for network: {}. Initialising new...",
+                chain_id
+            ),
+        }
+
+        // No web3 connection found for network_id, try the rest of the URLs
+        let web3_connection_locks = Mutex::new(());
+        for eth_node_url in self.eth_node_urls.iter() {
+            log::debug!("⛓️  Attempting to connect to Ethereum node: {}", eth_node_url);
+            let web3 = setup_web3_connection(&(eth_node_url.clone()).into());
+            if let Some(web3) = web3 {
+                // If we have a valid web3 connection, check the chain_id
+                let web3_chain_id = get_chain_id_from_provider(&web3).await.map_err(|e| {
+                    log::error!("Error getting chain ID from web3: {:?}", e);
+                    server_error("Error getting chain ID from web3".to_string())
+                })?;
+
                 log::info!(
-                    "⛓️  avn-service: web3 connection has already been initialised, skipping"
+                    "⛓️  Successfully connected to node: {} with chain ID: {}",
+                    eth_node_url,
+                    web3_chain_id
                 );
-                return Ok(())
+
+                {
+                    // Lock the mutex to ensure only one thread can alter the web3 connection
+                    let _ = web3_connection_locks.lock();
+
+                    if self.web3_data_mutexes.get(&web3_chain_id).is_some() {
+                        log::debug!(
+                            "⛓️  Web3 connection for chain ID {} already exists, skipping creation.",
+                            web3_chain_id
+                        );
+                        continue
+                    }
+
+                    // Create a new mutex for the web3 data and store it in the map
+                    let mut web3_data = Web3Data::new();
+                    web3_data.web3 = Some(web3);
+                    let web3_data_mutex = Arc::new(Mutex::new(web3_data));
+                    self.web3_data_mutexes.insert(web3_chain_id, Arc::clone(&web3_data_mutex));
+                }
+            } else {
+                log::error!("💔 Error creating a web3 connection for URL: {}", eth_node_url);
             }
+        }
 
-            let web3_init_time = Instant::now();
-            log::info!("⛓️  avn-service: web3 initialisation start");
-
-            // TODO fixme
-            let eth_web3_url =
-                self.eth_node_urls.first().cloned().unwrap_or_else(|| "".to_string());
-            let web3 = setup_web3_connection(&eth_web3_url);
-            if web3.is_none() {
-                log::error!(
-                    "💔 Error creating a web3 connection. URL is not valid {:?}",
-                    &self.eth_node_urls
-                );
-                return Err(server_error("Error creating a web3 connection".to_string()))
-            }
-
-            log::info!("⏲️  web3 init task completed in: {:?}", web3_init_time.elapsed());
-            web3_data_mutex.web3 = web3;
-            Ok(())
-        } else {
-            Err(server_error("Failed to acquire web3 data mutex.".to_string()))
+        log::info!("⏲️  web3 init task completed in: {:?}", web3_init_time.elapsed());
+        match self.web3_data_mutexes.get(&chain_id) {
+            Some(web3_data_pointer) => {
+                log::debug!("⛓️  Found existing web3 connection for network: {}", chain_id);
+                Ok(Arc::clone(web3_data_pointer))
+            },
+            None => Err(server_error(
+                "Failed to acquire a valid web3 connection for the instance.".to_string(),
+            )),
         }
     }
 }
@@ -510,9 +548,10 @@ pub const SLEEP_TIME: u64 = 60;
 pub const RETRY_LIMIT: usize = 3;
 pub const RETRY_DELAY: u64 = 5;
 
-async fn initialize_web3_with_retries<Block, ClientT>(
-    config: &EthEventHandlerConfig<Block, ClientT>,
-) -> Result<(), AppError>
+async fn initialize_web3_connection_for_instance<Block, ClientT>(
+    config: &mut EthEventHandlerConfig<Block, ClientT>,
+    instance: &EthBridgeInstance,
+) -> Result<Arc<Mutex<Web3Data>>, AppError>
 where
     Block: BlockT,
     ClientT: BlockBackend<Block>
@@ -526,10 +565,10 @@ where
     let mut attempts = 0;
 
     while attempts < RETRY_LIMIT {
-        match config.initialise_web3().await {
-            Ok(_) => {
+        match config.initialise_web3(instance.network.chain_id()).await {
+            Ok(web3_lock) => {
                 log::info!("Successfully initialized web3 connection.");
-                return Ok(())
+                return Ok(web3_lock)
             },
             Err(e) => {
                 attempts += 1;
@@ -579,10 +618,7 @@ where
         + ApiExt<Block>
         + BlockBuilder<Block>,
 {
-    if let Err(e) = initialize_web3_with_retries(&config).await {
-        log::error!("Web3 initialization ultimately failed: {:?}", e);
-        return
-    }
+    let mut config = config;
 
     let events_registry = EventRegistry::new();
 
@@ -617,7 +653,7 @@ where
     log::info!("Current node author address set: {:?}", current_node_author);
 
     loop {
-        match query_runtime_and_process(&config, &current_node_author, &events_registry).await {
+        match query_runtime_and_process(&mut config, &current_node_author, &events_registry).await {
             Ok(_) => (),
             Err(e) => log::error!("{}", e),
         }
@@ -628,7 +664,7 @@ where
 }
 
 async fn query_runtime_and_process<Block, ClientT>(
-    config: &EthEventHandlerConfig<Block, ClientT>,
+    config: &mut EthEventHandlerConfig<Block, ClientT>,
     current_node_author: &CurrentNodeAuthor,
     events_registry: &EventRegistry,
 ) -> Result<(), String>
@@ -663,16 +699,22 @@ where
     };
     log::debug!("Eth-bridge instances found: {:?}", &instances);
     for (instance_id, instance) in instances {
-        // TODO check if there is a web3 connection for the instance chain_id. If not, skip the
-        // instance
-
         let result = &config
             .client
             .runtime_api()
             .query_active_block_range(config.client.info().best_hash, instance_id)
             .map_err(|err| format!("Failed to query bridge contract: {:?}", err))?;
 
-        let web3_data_mutex = config.web3_data_mutex.lock().await;
+        let web3_data_lock = match initialize_web3_connection_for_instance(config, &instance).await
+        {
+            Ok(web3_data) => web3_data,
+            Err(e) => {
+                log::error!("Failed to initialize web3 connection for instance: {:?}", e);
+                continue
+            },
+        };
+
+        let web3_data_mutex = web3_data_lock.lock().await;
         let web3_ref = match web3_data_mutex.web3.as_ref() {
             Some(web3) => web3,
             None => return Err("Web3 connection not set up".into()),

--- a/node/avn-service/src/lib.rs
+++ b/node/avn-service/src/lib.rs
@@ -91,7 +91,7 @@ impl<Block: BlockT, ClientT: BlockBackend<Block> + UsageProvider<Block>> Config<
             let web3_init_time = Instant::now();
             log::info!("⛓️  avn-service: web3 initialisation start");
 
-            // TODO fixme
+            // Use the first rpc node for web3 operations
             let eth_web3_url =
                 self.eth_node_urls.first().cloned().unwrap_or_else(|| "".to_string());
 

--- a/node/avn-service/src/lib.rs
+++ b/node/avn-service/src/lib.rs
@@ -1,7 +1,6 @@
 use codec::{Decode, Encode};
 use futures::lock::Mutex;
 use hex::FromHex;
-use hex_literal::hex;
 use jsonrpc_core::ErrorCode;
 use sc_client_api::{client::BlockBackend, UsageProvider};
 use sc_keystore::LocalKeystore;
@@ -73,7 +72,7 @@ pub struct Config<Block: BlockT, ClientT: BlockBackend<Block> + UsageProvider<Bl
     pub keystore: Arc<LocalKeystore>,
     pub keystore_path: PathBuf,
     pub avn_port: Option<String>,
-    pub eth_node_url: String,
+    pub eth_node_urls: Vec<String>,
     pub web3_data_mutex: Arc<Mutex<Web3Data>>,
     pub client: Arc<ClientT>,
     pub _block: PhantomData<Block>,
@@ -92,11 +91,15 @@ impl<Block: BlockT, ClientT: BlockBackend<Block> + UsageProvider<Block>> Config<
             let web3_init_time = Instant::now();
             log::info!("⛓️  avn-service: web3 initialisation start");
 
-            let web3 = setup_web3_connection(&self.eth_node_url);
+            // TODO fixme
+            let eth_web3_url =
+                self.eth_node_urls.first().cloned().unwrap_or_else(|| "".to_string());
+
+            let web3 = setup_web3_connection(&eth_web3_url);
             if web3.is_none() {
                 log::error!(
                     "💔 Error creating a web3 connection. URL is not valid {:?}",
-                    &self.eth_node_url
+                    &self.eth_node_urls
                 );
                 return Err(server_error("Error creating a web3 connection".to_string()))
             }

--- a/node/avn-service/src/web3_utils.rs
+++ b/node/avn-service/src/web3_utils.rs
@@ -1,6 +1,7 @@
 use anyhow::{ensure, Context};
 use ethereum_types;
 use sp_avn_common::EthTransaction;
+use std::error::Error;
 pub use std::{
     error::Error as StdError,
     path::PathBuf,
@@ -225,4 +226,11 @@ pub fn secret_key_address(key: &SecretKey) -> Address {
     let secp: Secp256k1<All> = Secp256k1::new();
     let public_key = PublicKey::from_secret_key(&secp, key);
     public_key_address(&public_key)
+}
+
+pub async fn get_chain_id_from_provider(web3: &Web3<Http>) -> Result<u64, Box<dyn Error>> {
+    // Call eth_chainId
+    let chain_id = web3.eth().chain_id().await?;
+    log::trace!("Web3 connection has chain ID: {}", chain_id);
+    Ok(chain_id.as_u64())
 }

--- a/node/src/avn_config.rs
+++ b/node/src/avn_config.rs
@@ -7,5 +7,5 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 pub struct AvnCliConfiguration {
     pub avn_port: Option<String>,
-    pub ethereum_node_url: Option<String>,
+    pub ethereum_node_urls: Vec<String>,
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -62,8 +62,8 @@ pub struct AvnRunCmd {
     pub avn_port: Option<String>,
 
     /// URL for connecting with an ethereum node
-    #[arg(long = "ethereum-node-url", value_name = "ETH URL")]
-    pub eth_node_url: Option<String>,
+    #[arg(long = "ethereum-node-url", value_name = "ETH URL", num_args = 0..=5)]
+    pub eth_node_urls: Vec<String>,
 }
 
 impl std::ops::Deref for AvnRunCmd {

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -269,7 +269,7 @@ pub fn run() -> Result<()> {
 
                 let avn_config = AvnCliConfiguration {
                     avn_port: cli.run.avn_port,
-                    ethereum_node_url: cli.run.eth_node_url,
+                    ethereum_node_urls: cli.run.eth_node_urls,
                 };
 
                 info!("Parachain Account: {parachain_account}");

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -186,7 +186,6 @@ where
     let import_queue_service = params.import_queue.service();
 
     let avn_port = avn_cli_config.avn_port.clone();
-    let eth_node_url: String = avn_cli_config.ethereum_node_url.clone().unwrap_or_default();
 
     let (network, system_rpc_tx, tx_handler_controller, start_network, sync_service) =
         cumulus_client_service::build_network(cumulus_client_service::BuildNetworkParams {
@@ -323,7 +322,7 @@ where
             keystore: params.keystore_container.local_keystore(),
             keystore_path: keystore_path.clone(),
             avn_port: avn_port.clone(),
-            eth_node_url: eth_node_url.clone(),
+            eth_node_urls: avn_cli_config.ethereum_node_urls.clone(),
             web3_data_mutex: Arc::new(Mutex::new(Web3Data::new())),
             client: client.clone(),
             _block: Default::default(),
@@ -334,7 +333,7 @@ where
                 keystore: params.keystore_container.local_keystore(),
                 keystore_path: keystore_path.clone(),
                 avn_port: avn_port.clone(),
-                eth_node_url: eth_node_url.clone(),
+                eth_node_urls: avn_cli_config.ethereum_node_urls.clone(),
                 web3_data_mutex: Arc::new(Mutex::new(Web3Data::new())),
                 client: client.clone(),
                 _block: Default::default(),

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -334,9 +334,8 @@ where
                 keystore_path: keystore_path.clone(),
                 avn_port: avn_port.clone(),
                 eth_node_urls: avn_cli_config.ethereum_node_urls.clone(),
-                web3_data_mutex: Arc::new(Mutex::new(Web3Data::new())),
+                web3_data_mutexes: Default::default(),
                 client: client.clone(),
-                _block: Default::default(),
                 offchain_transaction_pool_factory: OffchainTransactionPoolFactory::new(
                     transaction_pool.clone(),
                 ),

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -148,6 +148,7 @@ const ADD_CORROBORATION_CONTEXT: &'static [u8] = b"EthBridgeCorroboration";
 const ADD_ETH_TX_HASH_CONTEXT: &'static [u8] = b"EthBridgeEthTxHash";
 pub const SUBMIT_ETHEREUM_EVENTS_HASH_CONTEXT: &'static [u8] = b"EthBridgeDiscoveredEthEventsHash";
 pub const SUBMIT_LATEST_ETH_BLOCK_CONTEXT: &'static [u8] = b"EthBridgeLatestEthereumBlockHash";
+pub const DEFAULT_ETH_RANGE: u32 = 20u32;
 
 const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
@@ -297,7 +298,7 @@ pub mod pallet {
 
     // The number of blocks that make up a range
     #[pallet::storage]
-    pub type EthBlockRangeSize<T: Config<I>, I: 'static = ()> = StorageValue<_, u32, ValueQuery>;
+    pub type EthBlockRangeSize<T: Config<I>, I: 'static = ()> = StorageValue<_, u32, ValueQuery, ConstU32<DEFAULT_ETH_RANGE>>;
 
     #[pallet::storage]
     pub type ProcessedEthereumEvents<T: Config<I>, I: 'static = ()> =

--- a/pallets/eth-bridge/src/migration.rs
+++ b/pallets/eth-bridge/src/migration.rs
@@ -40,7 +40,7 @@ impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for EthBridgeMigrations<T, I> {
         );
         let mut consumed_weight = Weight::zero();
 
-        if onchain < 2 {
+        if EthBlockRangeSize::<T, I>::get() == 0 {
             consumed_weight.saturating_accrue(set_block_range_size::<T, I>());
         }
 
@@ -58,7 +58,7 @@ impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for EthBridgeMigrations<T, I> {
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade(_input: Vec<u8>) -> Result<(), TryRuntimeError> {
-        frame_support::ensure!(EthBlockRangeSize::<T, I>::get() == 20u32, "Block range not set");
+        frame_support::ensure!(EthBlockRangeSize::<T, I>::get() == DEFAULT_ETH_RANGE, "Block range not set");
 
         Ok(())
     }
@@ -71,16 +71,12 @@ pub fn set_block_range_size<T: Config<I>, I: 'static>() -> Weight {
         consumed_weight += weight;
     };
 
-    EthBlockRangeSize::<T, I>::put(20u32);
-    let v2_storage: StorageVersion = StorageVersion::new(2);
-
-    v2_storage.put::<Pallet<T, I>>();
+    EthBlockRangeSize::<T, I>::put(DEFAULT_ETH_RANGE);
 
     // 2 Storage writes
     add_weight(0, 2, Weight::from_parts(0 as u64, 0));
 
     log::info!("✅ BlockRangeSize set successfully");
-
     return consumed_weight + Weight::from_parts(25_000 as u64, 0)
 }
 

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -771,7 +771,6 @@ impl pallet_preimage::Config for Runtime {
 }
 const MAIN_ETH_BRIDGE_ID: u8 = 0u8;
 
-
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
     // TODO is there any effect in making this a struct?


### PR DESCRIPTION
## Proposed changes

Enables support in the client for multiple RPC nodes and enables the ethereum events handler service to manage multiple web3 connections to networks and decide which connection is the right one for the instance

SYS-4601
SYS-4597
## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

