### PR TITLE
feat: Enables rotation of Ethereum keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-node-parachain"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "avn-parachain-runtime",
  "avn-parachain-test-runtime",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
@@ -7183,7 +7183,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-authors-manager"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7229,7 +7229,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7257,7 +7257,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-anchor"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7285,7 +7285,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7307,7 +7307,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7337,7 +7337,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -7675,7 +7675,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge-runtime-api"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "frame-support",
  "pallet-avn",
@@ -7690,7 +7690,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -7890,7 +7890,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8019,7 +8019,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8315,7 +8315,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8385,7 +8385,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -13237,7 +13237,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "6.11.0"
+version = "6.11.1"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "6.11.0"
+version = "6.11.1"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/pallets/authors-manager/src/benchmarking.rs
+++ b/pallets/authors-manager/src/benchmarking.rs
@@ -251,6 +251,23 @@ benchmarks! {
         assert_last_event::<T>(Event::<T>::AuthorDeregistered{ author_id: caller_account.clone() }.into());
         assert_eq!(true, AuthorActions::<T>::contains_key(caller_account, <TotalIngresses<T>>::get()));
     }
+
+    rotate_author_ethereum_key {
+    setup_additional_authors::<T>(2);
+    let (account_id, _, rotating_eth_key) = generate_resigning_author_account_details::<T>();
+    advance_session::<T>();
+    advance_session::<T>();
+
+    let eth_new_public_key: ecdsa::Public = Public::from_raw(NEW_AUTHOR_ETHEREUM_PUBLIC_KEY);
+
+    assert!(EthereumPublicKeys::<T>::get(&rotating_eth_key).is_some());
+    assert!(EthereumPublicKeys::<T>::get(&eth_new_public_key).is_none());
+
+    }: _(RawOrigin::Root, account_id, rotating_eth_key.clone(), eth_new_public_key.clone())
+    verify {
+        assert!(EthereumPublicKeys::<T>::get(&eth_new_public_key).is_some());
+        assert!(EthereumPublicKeys::<T>::get(&rotating_eth_key).is_none());
+    }
 }
 
 impl_benchmark_test_suite!(

--- a/pallets/authors-manager/src/default_weights.rs
+++ b/pallets/authors-manager/src/default_weights.rs
@@ -39,6 +39,7 @@ use core::marker::PhantomData;
 pub trait WeightInfo {
 	fn add_author() -> Weight;
 	fn remove_author(v: u32, ) -> Weight;
+	fn rotate_author_ethereum_key() -> Weight;
 }
 
 /// Weights for pallet_authors_manager using the Substrate node and recommended hardware.
@@ -101,6 +102,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 			.saturating_add(Weight::from_parts(0, 1839).saturating_mul(v.into()))
 	}
+	/// Storage: `AuthorsManager::EthereumPublicKeys` (r:2 w:2)
+	/// Proof: `AuthorsManager::EthereumPublicKeys` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	fn rotate_author_ethereum_key() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `310`
+		//  Estimated: `6102`
+		// Minimum execution time: 29_402_000 picoseconds.
+		Weight::from_parts(30_043_000, 6102)
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+
 }
 
 // For backwards compatibility and tests.
@@ -161,5 +174,16 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(v.into())))
 			.saturating_add(RocksDbWeight::get().writes(5_u64))
 			.saturating_add(Weight::from_parts(0, 1839).saturating_mul(v.into()))
+	}
+	/// Storage: `AuthorsManager::EthereumPublicKeys` (r:2 w:2)
+	/// Proof: `AuthorsManager::EthereumPublicKeys` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	fn rotate_author_ethereum_key() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `310`
+		//  Estimated: `6102`
+		// Minimum execution time: 29_402_000 picoseconds.
+		Weight::from_parts(30_043_000, 6102)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 }

--- a/pallets/authors-manager/src/lib.rs
+++ b/pallets/authors-manager/src/lib.rs
@@ -272,6 +272,10 @@ pub mod pallet {
                 !<EthereumPublicKeys<T>>::contains_key(&author_new_eth_public_key),
                 Error::<T>::AuthorEthKeyAlreadyExists
             );
+            ensure!(
+                author_old_eth_public_key != author_new_eth_public_key,
+                Error::<T>::AuthorEthKeyAlreadyExists
+            );
 
             let author_id = EthereumPublicKeys::<T>::take(&author_old_eth_public_key)
                 .ok_or(Error::<T>::AuthorNotFound)?;

--- a/pallets/authors-manager/src/lib.rs
+++ b/pallets/authors-manager/src/lib.rs
@@ -256,6 +256,30 @@ pub mod pallet {
 
             return Ok(())
         }
+
+        #[pallet::call_index(2)]
+        #[pallet::weight(Weight::zero())]
+        #[transactional]
+        pub fn rotate_author_ethereum_key(
+            origin: OriginFor<T>,
+            author_account_id: T::AccountId,
+            author_old_eth_public_key: ecdsa::Public,
+            author_new_eth_public_key: ecdsa::Public,
+        ) -> DispatchResult {
+            let _ = ensure_root(origin)?;
+
+            ensure!(
+                !<EthereumPublicKeys<T>>::contains_key(&author_new_eth_public_key),
+                Error::<T>::AuthorEthKeyAlreadyExists
+            );
+
+            let author_id = EthereumPublicKeys::<T>::take(&author_old_eth_public_key)
+                .ok_or(Error::<T>::AuthorNotFound)?;
+            ensure!(author_id == author_account_id, Error::<T>::AuthorNotFound);
+
+            EthereumPublicKeys::<T>::insert(author_new_eth_public_key, author_id);
+            return Ok(())
+        }
     }
 
     impl<T: Config> EthereumPublicKeyChecker<T::AccountId> for Pallet<T> {

--- a/pallets/authors-manager/src/lib.rs
+++ b/pallets/authors-manager/src/lib.rs
@@ -258,7 +258,7 @@ pub mod pallet {
         }
 
         #[pallet::call_index(2)]
-        #[pallet::weight(Weight::zero())]
+        #[pallet::weight(<T as Config>::WeightInfo::rotate_author_ethereum_key())]
         #[transactional]
         pub fn rotate_author_ethereum_key(
             origin: OriginFor<T>,

--- a/pallets/authors-manager/src/tests.rs
+++ b/pallets/authors-manager/src/tests.rs
@@ -614,6 +614,13 @@ mod rotate_author_ethereum_key {
                 .unwrap(),
                 context.author
             );
+
+            assert_eq!(
+                AuthorsManager::get_author_by_eth_public_key(
+                    context.author_eth_old_public_key.clone()
+                ),
+                None
+            );
         });
     }
 

--- a/pallets/validators-manager/src/benchmarking.rs
+++ b/pallets/validators-manager/src/benchmarking.rs
@@ -235,6 +235,23 @@ benchmarks! {
         assert_last_event::<T>(Event::<T>::ValidatorDeregistered{ validator_id: caller_account.clone() }.into());
         assert_eq!(true, ValidatorActions::<T>::contains_key(caller_account, <TotalIngresses<T>>::get()));
     }
+
+    rotate_validator_ethereum_key {
+        setup_additional_validators::<T>(2);
+        let (account_id, _, rotating_eth_key) = generate_resigning_collator_account_details::<T>();
+        advance_session::<T>();
+        advance_session::<T>();
+
+        let eth_new_public_key: ecdsa::Public = Public::from_raw(NEW_COLLATOR_ETHEREUM_PUBLIC_KEY);
+
+        assert!(EthereumPublicKeys::<T>::get(&rotating_eth_key).is_some());
+        assert!(EthereumPublicKeys::<T>::get(&eth_new_public_key).is_none());
+
+    }: _(RawOrigin::Root, account_id, rotating_eth_key.clone(), eth_new_public_key.clone())
+    verify {
+        assert!(EthereumPublicKeys::<T>::get(&eth_new_public_key).is_some());
+        assert!(EthereumPublicKeys::<T>::get(&rotating_eth_key).is_none());
+    }
 }
 
 impl_benchmark_test_suite!(

--- a/pallets/validators-manager/src/default_weights.rs
+++ b/pallets/validators-manager/src/default_weights.rs
@@ -39,6 +39,7 @@ use core::marker::PhantomData;
 pub trait WeightInfo {
 	fn add_collator() -> Weight;
 	fn remove_validator(v: u32, ) -> Weight;
+	fn rotate_validator_ethereum_key() -> Weight;
 }
 
 /// Weights for pallet_validators_manager using the Substrate node and recommended hardware.
@@ -133,6 +134,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(7_u64))
 			.saturating_add(Weight::from_parts(0, 1839).saturating_mul(v.into()))
 	}
+	/// Storage: `ValidatorsManager::EthereumPublicKeys` (r:2 w:2)
+	/// Proof: `ValidatorsManager::EthereumPublicKeys` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	fn rotate_validator_ethereum_key() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `310`
+		//  Estimated: `6102`
+		// Minimum execution time: 29_402_000 picoseconds.
+		Weight::from_parts(30_043_000, 6102)
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
 }
 
 // For backwards compatibility and tests.
@@ -225,5 +237,16 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(v.into())))
 			.saturating_add(RocksDbWeight::get().writes(7_u64))
 			.saturating_add(Weight::from_parts(0, 1839).saturating_mul(v.into()))
+	}
+	/// Storage: `ValidatorsManager::EthereumPublicKeys` (r:2 w:2)
+	/// Proof: `ValidatorsManager::EthereumPublicKeys` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	fn rotate_validator_ethereum_key() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `310`
+		//  Estimated: `6102`
+		// Minimum execution time: 29_402_000 picoseconds.
+		Weight::from_parts(30_043_000, 6102)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 }

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -290,6 +290,30 @@ pub mod pallet {
             )
             .into())
         }
+
+        #[pallet::call_index(2)]
+        #[pallet::weight(Weight::zero())]
+        #[transactional]
+        pub fn rotate_validator_ethereum_key(
+            origin: OriginFor<T>,
+            author_account_id: T::AccountId,
+            author_old_eth_public_key: ecdsa::Public,
+            author_new_eth_public_key: ecdsa::Public,
+        ) -> DispatchResult {
+            let _ = ensure_root(origin)?;
+
+            ensure!(
+                !<EthereumPublicKeys<T>>::contains_key(&author_new_eth_public_key),
+                Error::<T>::ValidatorEthKeyAlreadyExists
+            );
+
+            let author_id = EthereumPublicKeys::<T>::take(&author_old_eth_public_key)
+                .ok_or(Error::<T>::ValidatorNotFound)?;
+            ensure!(author_id == author_account_id, Error::<T>::ValidatorNotFound);
+
+            EthereumPublicKeys::<T>::insert(author_new_eth_public_key, author_id);
+            return Ok(())
+        }
     }
 }
 

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -292,7 +292,7 @@ pub mod pallet {
         }
 
         #[pallet::call_index(2)]
-        #[pallet::weight(Weight::zero())]
+        #[pallet::weight(<T as Config>::WeightInfo::rotate_validator_ethereum_key())]
         #[transactional]
         pub fn rotate_validator_ethereum_key(
             origin: OriginFor<T>,

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -306,6 +306,10 @@ pub mod pallet {
                 !<EthereumPublicKeys<T>>::contains_key(&author_new_eth_public_key),
                 Error::<T>::ValidatorEthKeyAlreadyExists
             );
+            ensure!(
+                author_old_eth_public_key != author_new_eth_public_key,
+                Error::<T>::ValidatorEthKeyAlreadyExists
+            );
 
             let author_id = EthereumPublicKeys::<T>::take(&author_old_eth_public_key)
                 .ok_or(Error::<T>::ValidatorNotFound)?;

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -663,7 +663,6 @@ mod rotate_validator_ethereum_key {
                 ),
                 None
             );
-
         });
     }
 

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -657,6 +657,13 @@ mod rotate_validator_ethereum_key {
                 .unwrap(),
                 context.validator
             );
+            assert_eq!(
+                ValidatorManager::get_validator_by_eth_public_key(
+                    context.validator_eth_old_public_key.clone()
+                ),
+                None
+            );
+
         });
     }
 

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -179,7 +179,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 104,
+    spec_version: 105,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -180,7 +180,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-test-parachain"),
     impl_name: create_runtime_str!("avn-test-parachain"),
     authoring_version: 1,
-    spec_version: 104,
+    spec_version: 105,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Proposed changes

Adds new sudo operation that allows to rotate the ethereum key of an existing author/validator.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [x] Patch release <!---i.ex v1.0.0 => v1.0.1-->

