### PR TITLE
feat: Enables rotation of Ethereum keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avn-lower-rpc"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "avn-service",
  "futures",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "avn-node-parachain"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "avn-lower-rpc",
  "avn-parachain-runtime",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-runtime"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "avn-parachain-test-runtime"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "avn-runtime-common",
  "cumulus-pallet-aura-ext",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "avn-runtime-common"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "avn-service"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
@@ -6968,7 +6968,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-authors-manager"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7014,7 +7014,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7042,7 +7042,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-anchor"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-offence-handler"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7092,7 +7092,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-proxy"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7122,7 +7122,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-avn-transaction-payment"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7413,7 +7413,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "ethabi 13.0.0",
  "frame-benchmarking",
@@ -7442,7 +7442,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-eth-bridge-runtime-api"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "frame-support",
  "pallet-avn",
@@ -7456,7 +7456,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum-events"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "env_logger 0.10.0",
  "frame-benchmarking",
@@ -7654,7 +7654,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-manager"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7783,7 +7783,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8062,7 +8062,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-summary"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-token-manager"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8240,7 +8240,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validators-manager"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -13059,7 +13059,7 @@ dependencies = [
 
 [[package]]
 name = "sp-avn-common"
-version = "6.8.4"
+version = "6.8.5"
 dependencies = [
  "byte-slice-cast",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "6.8.4"
+version = "6.8.5"
 authors = ["Aventus systems team"]
 homepage = "https://www.aventus.io/"
 repository = "https://github.com/Aventus-Network-Services/avn-node-parachain/"

--- a/pallets/authors-manager/src/benchmarking.rs
+++ b/pallets/authors-manager/src/benchmarking.rs
@@ -251,6 +251,23 @@ benchmarks! {
         assert_last_event::<T>(Event::<T>::AuthorDeregistered{ author_id: caller_account.clone() }.into());
         assert_eq!(true, AuthorActions::<T>::contains_key(caller_account, <TotalIngresses<T>>::get()));
     }
+
+    rotate_author_ethereum_key {
+    setup_additional_authors::<T>(2);
+    let (account_id, _, rotating_eth_key) = generate_resigning_author_account_details::<T>();
+    advance_session::<T>();
+    advance_session::<T>();
+
+    let eth_new_public_key: ecdsa::Public = Public::from_raw(NEW_AUTHOR_ETHEREUM_PUBLIC_KEY);
+
+    assert!(EthereumPublicKeys::<T>::get(&rotating_eth_key).is_some());
+    assert!(EthereumPublicKeys::<T>::get(&eth_new_public_key).is_none());
+
+    }: _(RawOrigin::Root, account_id, rotating_eth_key.clone(), eth_new_public_key.clone())
+    verify {
+        assert!(EthereumPublicKeys::<T>::get(&eth_new_public_key).is_some());
+        assert!(EthereumPublicKeys::<T>::get(&rotating_eth_key).is_none());
+    }
 }
 
 impl_benchmark_test_suite!(

--- a/pallets/authors-manager/src/default_weights.rs
+++ b/pallets/authors-manager/src/default_weights.rs
@@ -39,6 +39,7 @@ use core::marker::PhantomData;
 pub trait WeightInfo {
 	fn add_author() -> Weight;
 	fn remove_author(v: u32, ) -> Weight;
+	fn rotate_author_ethereum_key() -> Weight;
 }
 
 /// Weights for pallet_authors_manager using the Substrate node and recommended hardware.
@@ -101,6 +102,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 			.saturating_add(Weight::from_parts(0, 1839).saturating_mul(v.into()))
 	}
+	/// Storage: `AuthorsManager::EthereumPublicKeys` (r:2 w:2)
+	/// Proof: `AuthorsManager::EthereumPublicKeys` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	fn rotate_author_ethereum_key() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `310`
+		//  Estimated: `6102`
+		// Minimum execution time: 29_402_000 picoseconds.
+		Weight::from_parts(30_043_000, 6102)
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+
 }
 
 // For backwards compatibility and tests.
@@ -161,5 +174,16 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(v.into())))
 			.saturating_add(RocksDbWeight::get().writes(5_u64))
 			.saturating_add(Weight::from_parts(0, 1839).saturating_mul(v.into()))
+	}
+	/// Storage: `AuthorsManager::EthereumPublicKeys` (r:2 w:2)
+	/// Proof: `AuthorsManager::EthereumPublicKeys` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	fn rotate_author_ethereum_key() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `310`
+		//  Estimated: `6102`
+		// Minimum execution time: 29_402_000 picoseconds.
+		Weight::from_parts(30_043_000, 6102)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 }

--- a/pallets/authors-manager/src/tests.rs
+++ b/pallets/authors-manager/src/tests.rs
@@ -562,3 +562,161 @@ mod bridge_interface_notification {
         }
     }
 }
+
+mod rotate_author_ethereum_key {
+    use sp_core::ByteArray;
+
+    use super::*;
+
+    struct RotateAuthorEthKeyContext {
+        author: AccountId,
+        author_eth_old_public_key: ecdsa::Public,
+        author_eth_new_public_key: ecdsa::Public,
+    }
+
+    impl Default for RotateAuthorEthKeyContext {
+        fn default() -> Self {
+            let author = author_id_1();
+            Balances::make_free_balance_be(&author, 100000);
+
+            RotateAuthorEthKeyContext {
+                author,
+                author_eth_old_public_key: ecdsa::Public::from_slice(&AUTHOR_1_ETHEREUM_PUPLIC_KEY)
+                    .unwrap(),
+                author_eth_new_public_key: ecdsa::Public::from_raw(hex!(
+                    "02407b0d9f41148bbe3b6c7d4a62585ae66cc32a707441197fa5453abfebd31d57"
+                )),
+            }
+        }
+    }
+
+    #[test]
+    fn succeeds_with_good_parameters() {
+        let mut ext = ExtBuilder::build_default().with_authors().as_externality();
+        ext.execute_with(|| {
+            let context = &RotateAuthorEthKeyContext::default();
+
+            assert_ok!(AuthorsManager::rotate_author_ethereum_key(
+                RuntimeOrigin::root(),
+                context.author.clone(),
+                context.author_eth_old_public_key.clone(),
+                context.author_eth_new_public_key.clone()
+            ));
+
+            assert_eq!(
+                true,
+                AuthorsManager::author_account_ids().unwrap().contains(&context.author)
+            );
+            assert_eq!(
+                AuthorsManager::get_author_by_eth_public_key(
+                    context.author_eth_new_public_key.clone()
+                )
+                .unwrap(),
+                context.author
+            );
+
+            assert_eq!(
+                AuthorsManager::get_author_by_eth_public_key(
+                    context.author_eth_old_public_key.clone()
+                ),
+                None
+            );
+        });
+    }
+
+    mod fails_when {
+        use super::*;
+
+        #[test]
+        fn extrinsic_is_unsigned() {
+            let mut ext = ExtBuilder::build_default().with_authors().as_externality();
+            ext.execute_with(|| {
+                let context = &RotateAuthorEthKeyContext::default();
+
+                assert_noop!(
+                    AuthorsManager::rotate_author_ethereum_key(
+                        RuntimeOrigin::none(),
+                        context.author.clone(),
+                        context.author_eth_old_public_key.clone(),
+                        context.author_eth_new_public_key.clone()
+                    ),
+                    BadOrigin
+                );
+            });
+        }
+
+        #[test]
+        fn author_eth_key_already_exists() {
+            let mut ext = ExtBuilder::build_default().with_authors().as_externality();
+            ext.execute_with(|| {
+                let context = &RotateAuthorEthKeyContext::default();
+
+                assert_noop!(
+                    AuthorsManager::rotate_author_ethereum_key(
+                        RuntimeOrigin::root(),
+                        context.author.clone(),
+                        context.author_eth_old_public_key.clone(),
+                        ecdsa::Public::from_slice(&AUTHOR_2_ETHEREUM_PUPLIC_KEY).unwrap()
+                    ),
+                    Error::<TestRuntime>::AuthorEthKeyAlreadyExists
+                );
+            });
+        }
+
+        #[test]
+        fn author_eth_key_unchanged() {
+            let mut ext = ExtBuilder::build_default().with_authors().as_externality();
+            ext.execute_with(|| {
+                let context = &RotateAuthorEthKeyContext::default();
+
+                assert_noop!(
+                    AuthorsManager::rotate_author_ethereum_key(
+                        RuntimeOrigin::root(),
+                        context.author.clone(),
+                        context.author_eth_old_public_key.clone(),
+                        context.author_eth_old_public_key.clone(),
+                    ),
+                    Error::<TestRuntime>::AuthorEthKeyAlreadyExists
+                );
+            });
+        }
+
+        #[test]
+        fn author_not_found() {
+            let mut ext = ExtBuilder::build_default().with_authors().as_externality();
+            ext.execute_with(|| {
+                let context = &RotateAuthorEthKeyContext::default();
+
+                let no_author = TestAccount::new([6u8; 32]).account_id();
+
+                assert_noop!(
+                    AuthorsManager::rotate_author_ethereum_key(
+                        RuntimeOrigin::root(),
+                        no_author,
+                        context.author_eth_old_public_key.clone(),
+                        context.author_eth_new_public_key.clone()
+                    ),
+                    Error::<TestRuntime>::AuthorNotFound
+                );
+            });
+        }
+
+        #[test]
+        fn author_keys_missmatch() {
+            let mut ext = ExtBuilder::build_default().with_authors().as_externality();
+            ext.execute_with(|| {
+                let context = &RotateAuthorEthKeyContext::default();
+
+                assert_noop!(
+                    AuthorsManager::rotate_author_ethereum_key(
+                        RuntimeOrigin::root(),
+                        author_id_5(),
+                        context.author_eth_old_public_key.clone(),
+                        context.author_eth_new_public_key.clone()
+                    ),
+                    Error::<TestRuntime>::AuthorNotFound
+                );
+            });
+        }
+    }
+}

--- a/pallets/validators-manager/src/benchmarking.rs
+++ b/pallets/validators-manager/src/benchmarking.rs
@@ -235,6 +235,23 @@ benchmarks! {
         assert_last_event::<T>(Event::<T>::ValidatorDeregistered{ validator_id: caller_account.clone() }.into());
         assert_eq!(true, ValidatorActions::<T>::contains_key(caller_account, <TotalIngresses<T>>::get()));
     }
+
+    rotate_validator_ethereum_key {
+        setup_additional_validators::<T>(2);
+        let (account_id, _, rotating_eth_key) = generate_resigning_collator_account_details::<T>();
+        advance_session::<T>();
+        advance_session::<T>();
+
+        let eth_new_public_key: ecdsa::Public = Public::from_raw(NEW_COLLATOR_ETHEREUM_PUBLIC_KEY);
+
+        assert!(EthereumPublicKeys::<T>::get(&rotating_eth_key).is_some());
+        assert!(EthereumPublicKeys::<T>::get(&eth_new_public_key).is_none());
+
+    }: _(RawOrigin::Root, account_id, rotating_eth_key.clone(), eth_new_public_key.clone())
+    verify {
+        assert!(EthereumPublicKeys::<T>::get(&eth_new_public_key).is_some());
+        assert!(EthereumPublicKeys::<T>::get(&rotating_eth_key).is_none());
+    }
 }
 
 impl_benchmark_test_suite!(

--- a/pallets/validators-manager/src/default_weights.rs
+++ b/pallets/validators-manager/src/default_weights.rs
@@ -39,6 +39,7 @@ use core::marker::PhantomData;
 pub trait WeightInfo {
 	fn add_collator() -> Weight;
 	fn remove_validator(v: u32, ) -> Weight;
+	fn rotate_validator_ethereum_key() -> Weight;
 }
 
 /// Weights for pallet_validators_manager using the Substrate node and recommended hardware.
@@ -131,6 +132,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(7_u64))
 			.saturating_add(Weight::from_parts(0, 1839).saturating_mul(v.into()))
 	}
+	/// Storage: `ValidatorsManager::EthereumPublicKeys` (r:2 w:2)
+	/// Proof: `ValidatorsManager::EthereumPublicKeys` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	fn rotate_validator_ethereum_key() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `310`
+		//  Estimated: `6102`
+		// Minimum execution time: 29_402_000 picoseconds.
+		Weight::from_parts(30_043_000, 6102)
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
 }
 
 // For backwards compatibility and tests.
@@ -221,5 +233,16 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(v.into())))
 			.saturating_add(RocksDbWeight::get().writes(7_u64))
 			.saturating_add(Weight::from_parts(0, 1839).saturating_mul(v.into()))
+	}
+	/// Storage: `ValidatorsManager::EthereumPublicKeys` (r:2 w:2)
+	/// Proof: `ValidatorsManager::EthereumPublicKeys` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+	fn rotate_validator_ethereum_key() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `310`
+		//  Estimated: `6102`
+		// Minimum execution time: 29_402_000 picoseconds.
+		Weight::from_parts(30_043_000, 6102)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 }

--- a/pallets/validators-manager/src/lib.rs
+++ b/pallets/validators-manager/src/lib.rs
@@ -290,6 +290,34 @@ pub mod pallet {
             )
             .into())
         }
+
+        #[pallet::call_index(2)]
+        #[pallet::weight(<T as Config>::WeightInfo::rotate_validator_ethereum_key())]
+        #[transactional]
+        pub fn rotate_validator_ethereum_key(
+            origin: OriginFor<T>,
+            author_account_id: T::AccountId,
+            author_old_eth_public_key: ecdsa::Public,
+            author_new_eth_public_key: ecdsa::Public,
+        ) -> DispatchResult {
+            let _ = ensure_root(origin)?;
+
+            ensure!(
+                !<EthereumPublicKeys<T>>::contains_key(&author_new_eth_public_key),
+                Error::<T>::ValidatorEthKeyAlreadyExists
+            );
+            ensure!(
+                author_old_eth_public_key != author_new_eth_public_key,
+                Error::<T>::ValidatorEthKeyAlreadyExists
+            );
+
+            let author_id = EthereumPublicKeys::<T>::take(&author_old_eth_public_key)
+                .ok_or(Error::<T>::ValidatorNotFound)?;
+            ensure!(author_id == author_account_id, Error::<T>::ValidatorNotFound);
+
+            EthereumPublicKeys::<T>::insert(author_new_eth_public_key, author_id);
+            return Ok(())
+        }
     }
 }
 

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -603,3 +603,162 @@ mod add_validator {
         }
     }
 }
+
+mod rotate_validator_ethereum_key {
+    use sp_core::ByteArray;
+
+    use super::*;
+
+    struct RotateValidatorEthKeyContext {
+        validator: AccountId,
+        validator_eth_old_public_key: ecdsa::Public,
+        validator_eth_new_public_key: ecdsa::Public,
+    }
+
+    impl Default for RotateValidatorEthKeyContext {
+        fn default() -> Self {
+            let validator = validator_id_1();
+            Balances::make_free_balance_be(&validator, 100000);
+
+            RotateValidatorEthKeyContext {
+                validator,
+                validator_eth_old_public_key: ecdsa::Public::from_slice(
+                    &COLLATOR_1_ETHEREUM_PUPLIC_KEY,
+                )
+                .unwrap(),
+                validator_eth_new_public_key: ecdsa::Public::from_raw(hex!(
+                    "02407b0d9f41148bbe3b6c7d4a62585ae66cc32a707441197fa5453abfebd31d57"
+                )),
+            }
+        }
+    }
+
+    #[test]
+    fn succeeds_with_good_parameters() {
+        let mut ext = ExtBuilder::build_default().with_validators().as_externality();
+        ext.execute_with(|| {
+            let context = &RotateValidatorEthKeyContext::default();
+
+            assert_ok!(ValidatorManager::rotate_validator_ethereum_key(
+                RuntimeOrigin::root(),
+                context.validator.clone(),
+                context.validator_eth_old_public_key.clone(),
+                context.validator_eth_new_public_key.clone()
+            ));
+
+            assert_eq!(
+                true,
+                ValidatorManager::validator_account_ids().unwrap().contains(&context.validator)
+            );
+            assert_eq!(
+                ValidatorManager::get_validator_by_eth_public_key(
+                    context.validator_eth_new_public_key.clone()
+                )
+                .unwrap(),
+                context.validator
+            );
+            assert_eq!(
+                ValidatorManager::get_validator_by_eth_public_key(
+                    context.validator_eth_old_public_key.clone()
+                ),
+                None
+            );
+        });
+    }
+
+    mod fails_when {
+        use super::*;
+
+        #[test]
+        fn extrinsic_is_unsigned() {
+            let mut ext = ExtBuilder::build_default().with_validators().as_externality();
+            ext.execute_with(|| {
+                let context = &RotateValidatorEthKeyContext::default();
+
+                assert_noop!(
+                    ValidatorManager::rotate_validator_ethereum_key(
+                        RuntimeOrigin::none(),
+                        context.validator.clone(),
+                        context.validator_eth_old_public_key.clone(),
+                        context.validator_eth_new_public_key.clone()
+                    ),
+                    BadOrigin
+                );
+            });
+        }
+
+        #[test]
+        fn validator_eth_key_already_exists() {
+            let mut ext = ExtBuilder::build_default().with_validators().as_externality();
+            ext.execute_with(|| {
+                let context = &RotateValidatorEthKeyContext::default();
+
+                assert_noop!(
+                    ValidatorManager::rotate_validator_ethereum_key(
+                        RuntimeOrigin::root(),
+                        context.validator.clone(),
+                        context.validator_eth_old_public_key.clone(),
+                        ecdsa::Public::from_slice(&COLLATOR_2_ETHEREUM_PUPLIC_KEY).unwrap()
+                    ),
+                    Error::<TestRuntime>::ValidatorEthKeyAlreadyExists
+                );
+            });
+        }
+
+        #[test]
+        fn validator_eth_key_unchanged() {
+            let mut ext = ExtBuilder::build_default().with_validators().as_externality();
+            ext.execute_with(|| {
+                let context = &RotateValidatorEthKeyContext::default();
+
+                assert_noop!(
+                    ValidatorManager::rotate_validator_ethereum_key(
+                        RuntimeOrigin::root(),
+                        context.validator.clone(),
+                        context.validator_eth_old_public_key.clone(),
+                        context.validator_eth_old_public_key.clone(),
+                    ),
+                    Error::<TestRuntime>::ValidatorEthKeyAlreadyExists
+                );
+            });
+        }
+
+        #[test]
+        fn validator_not_found() {
+            let mut ext = ExtBuilder::build_default().with_validators().as_externality();
+            ext.execute_with(|| {
+                let context = &RotateValidatorEthKeyContext::default();
+
+                let no_validator = TestAccount::new([6u8; 32]).account_id();
+
+                assert_noop!(
+                    ValidatorManager::rotate_validator_ethereum_key(
+                        RuntimeOrigin::root(),
+                        no_validator,
+                        context.validator_eth_old_public_key.clone(),
+                        context.validator_eth_new_public_key.clone()
+                    ),
+                    Error::<TestRuntime>::ValidatorNotFound
+                );
+            });
+        }
+
+        #[test]
+        fn validator_keys_missmatch() {
+            let mut ext = ExtBuilder::build_default().with_validators().as_externality();
+            ext.execute_with(|| {
+                let context = &RotateValidatorEthKeyContext::default();
+
+                assert_noop!(
+                    ValidatorManager::rotate_validator_ethereum_key(
+                        RuntimeOrigin::root(),
+                        validator_id_5(),
+                        context.validator_eth_old_public_key.clone(),
+                        context.validator_eth_new_public_key.clone()
+                    ),
+                    Error::<TestRuntime>::ValidatorNotFound
+                );
+            });
+        }
+    }
+}

--- a/runtime/avn/src/lib.rs
+++ b/runtime/avn/src/lib.rs
@@ -174,7 +174,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-parachain"),
     impl_name: create_runtime_str!("avn-parachain"),
     authoring_version: 1,
-    spec_version: 90,
+    spec_version: 91,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -197,7 +197,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("avn-test-parachain"),
     impl_name: create_runtime_str!("avn-test-parachain"),
     authoring_version: 1,
-    spec_version: 90,
+    spec_version: 91,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Adds new sudo operation that allows to rotate the ethereum key of an existing author/validator.

## Proposed changes

<!---Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.-->

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->
