### PR TITLE
feat: enable offences for invalid ethereum ranges votes

### DIFF
--- a/pallets/eth-bridge/src/tests/mock.rs
+++ b/pallets/eth-bridge/src/tests/mock.rs
@@ -39,7 +39,7 @@ pub type AccountId = u64;
 pub type BlockNumber = u64;
 
 type IdentificationTuple = (AccountId, AccountId);
-type Offence = crate::CorroborationOffence<IdentificationTuple>;
+type Offence = crate::EthBridgeOffence<IdentificationTuple>;
 pub struct OffenceHandler;
 impl ReportOffence<AccountId, IdentificationTuple, Offence> for OffenceHandler {
     fn report_offence(reporters: Vec<AccountId>, offence: Offence) -> Result<(), OffenceError> {

--- a/pallets/eth-bridge/src/tx.rs
+++ b/pallets/eth-bridge/src/tx.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{offence::create_and_report_corroboration_offence, Config};
+use crate::{offence::create_and_report_bridge_offence, Config};
 use frame_support::BoundedVec;
 use sp_avn_common::eth::{create_function_confirmation_hash, EthereumId};
 
@@ -24,10 +24,10 @@ fn complete_transaction<T: Config<I>, I: 'static>(
     // Check for offences:
     if success {
         if !tx.data.failure_corroborations.is_empty() {
-            create_and_report_corroboration_offence::<T, I>(
+            create_and_report_bridge_offence::<T, I>(
                 &tx.data.sender,
                 &tx.data.failure_corroborations,
-                offence::CorroborationOffenceType::ChallengeAttemptedOnSuccessfulTransaction,
+                offence::EthBridgeOffenceType::ChallengeAttemptedOnSuccessfulTransaction,
             )
         }
 
@@ -37,10 +37,10 @@ fn complete_transaction<T: Config<I>, I: 'static>(
         }
     } else {
         if !tx.data.success_corroborations.is_empty() {
-            create_and_report_corroboration_offence::<T, I>(
+            create_and_report_bridge_offence::<T, I>(
                 &tx.data.sender,
                 &tx.data.success_corroborations,
-                offence::CorroborationOffenceType::ChallengeAttemptedOnUnsuccessfulTransaction,
+                offence::EthBridgeOffenceType::ChallengeAttemptedOnUnsuccessfulTransaction,
             )
         }
     }

--- a/pallets/summary/src/tests/mock.rs
+++ b/pallets/summary/src/tests/mock.rs
@@ -8,7 +8,7 @@ use frame_system::{self as system, DefaultConfig};
 use pallet_avn::{
     self as avn, testing::U64To32BytesConverter, vote::VotingSessionData, EthereumPublicKeyChecker,
 };
-use pallet_eth_bridge::offence::CorroborationOffence;
+use pallet_eth_bridge::offence::EthBridgeOffence;
 use pallet_session as session;
 use parking_lot::RwLock;
 use sp_avn_common::{eth::LowerParams, safe_add_block_numbers, safe_sub_block_numbers};
@@ -526,7 +526,7 @@ type Offence = crate::SummaryOffence<IdentificationTuple>;
 
 thread_local! {
     pub static OFFENCES: RefCell<Vec<(Vec<ValidatorId>, Offence)>> = RefCell::new(vec![]);
-    pub static ETH_BRIDGE_OFFENCES: RefCell<Vec<(Vec<ValidatorId>, CorroborationOffence<IdentificationTuple>)>> = RefCell::new(vec![]);
+    pub static ETH_BRIDGE_OFFENCES: RefCell<Vec<(Vec<ValidatorId>, EthBridgeOffence<IdentificationTuple>)>> = RefCell::new(vec![]);
 }
 
 /// A mock offence report handler.
@@ -542,12 +542,12 @@ impl ReportOffence<AccountId, IdentificationTuple, Offence> for OffenceHandler {
     }
 }
 
-impl ReportOffence<AccountId, IdentificationTuple, CorroborationOffence<IdentificationTuple>>
+impl ReportOffence<AccountId, IdentificationTuple, EthBridgeOffence<IdentificationTuple>>
     for OffenceHandler
 {
     fn report_offence(
         reporters: Vec<AccountId>,
-        offence: CorroborationOffence<IdentificationTuple>,
+        offence: EthBridgeOffence<IdentificationTuple>,
     ) -> Result<(), OffenceError> {
         ETH_BRIDGE_OFFENCES.with(|l| l.borrow_mut().push((reporters, offence)));
         Ok(())


### PR DESCRIPTION
## Proposed changes
Address TODO and implement offences for invalid Ethereum ranges.
Revisits the slash_fraction implementation, mimicking the equivocation logic
and makes the offences generic for all cases.

References:
- M-05
- SYS-4662

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

