### PR TITLE
feat(avn-service): require signed proof for sign/send operations

### DIFF
--- a/pallets/avn/src/lib.rs
+++ b/pallets/avn/src/lib.rs
@@ -384,21 +384,26 @@ impl<T: Config> Pallet<T> {
     pub fn post_data_to_service(
         url_path: String,
         post_body: Vec<u8>,
+        proof_maybe: Option<<T::AuthorityId as RuntimeAppPublic>::Signature>,
     ) -> Result<Vec<u8>, DispatchError> {
-        let request = http::Request::default().method(http::Method::Post).body(vec![post_body]);
+        let mut request = http::Request::default().method(http::Method::Post).body(vec![post_body]);
+        if let Some(proof) = proof_maybe {
+            request = request.add_header("X-Service-Proof", &format!("{:?}", proof));
+        }
 
         return Ok(Self::invoke_external_service(request, url_path)?)
     }
 
     pub fn request_ecdsa_signature_from_external_service(
         data_to_sign: &str,
+        proof_maybe: Option<<T::AuthorityId as RuntimeAppPublic>::Signature>,
     ) -> Result<ecdsa::Signature, DispatchError> {
         let mut url = String::from("eth/sign_hashed_data/");
         url.push_str(data_to_sign);
 
         log::info!(target: "avn-service", "avn-service sign request (ecdsa) for hex-encoded data {:?}", data_to_sign);
 
-        let ecdsa_signature_utf8 = Self::get_data_from_service(url)?;
+        let ecdsa_signature_utf8 = Self::post_data_to_service(url, vec![], proof_maybe)?;
         let ecdsa_signature_bytes = core::str::from_utf8(&ecdsa_signature_utf8)
             .map_err(|_| Error::<T>::ErrorConvertingUtf8)?;
 

--- a/pallets/eth-bridge/src/lib.rs
+++ b/pallets/eth-bridge/src/lib.rs
@@ -861,7 +861,8 @@ pub mod pallet {
             match req.request {
                 Request::LowerProof(lower_req) =>
                     if !has_enough_confirmations {
-                        let confirmation = eth::sign_msg_hash::<T, I>(&req.confirmation.msg_hash)?;
+                        let confirmation =
+                            eth::sign_msg_hash::<T, I>(&author, &req.confirmation.msg_hash)?;
                         if !req.confirmation.confirmations.contains(&confirmation) {
                             call::add_confirmation::<T, I>(
                                 lower_req.lower_id,
@@ -875,7 +876,8 @@ pub mod pallet {
                     let self_is_sender = author.account_id == tx.data.sender;
                     // Plus 1 for sender
                     if !self_is_sender && !has_enough_confirmations {
-                        let confirmation = eth::sign_msg_hash::<T, I>(&tx.confirmation.msg_hash)?;
+                        let confirmation =
+                            eth::sign_msg_hash::<T, I>(&author, &tx.confirmation.msg_hash)?;
                         if !tx.confirmation.confirmations.contains(&confirmation) {
                             call::add_confirmation::<T, I>(tx.request.tx_id, confirmation, author);
                         }
@@ -910,7 +912,7 @@ pub mod pallet {
 
             // Protect against sending more than once
             if let Ok(guard) = lock.try_lock() {
-                let eth_tx_hash = eth::send_tx::<T, I>(&tx)?;
+                let eth_tx_hash = eth::send_tx::<T, I>(&author, &tx)?;
                 call::add_eth_tx_hash::<T, I>(tx.request.tx_id, eth_tx_hash, author);
                 guard.forget(); // keep the lock so we don't send again
             } else {
@@ -1230,6 +1232,7 @@ pub mod pallet {
                 calldata,
                 |data| Ok(data),
                 eth_block,
+                None,
             )
         }
 

--- a/pallets/ethereum-events/src/lib.rs
+++ b/pallets/ethereum-events/src/lib.rs
@@ -1501,7 +1501,7 @@ impl<T: Config> Pallet<T> {
         let contract_address = AVN::<T>::get_bridge_contract_address();
         let ethereum_call = EthTransaction::new(sender, contract_address, calldata.encode());
 
-        AVN::<T>::post_data_to_service("/eth/query".to_string(), ethereum_call.encode())
+        AVN::<T>::post_data_to_service("/eth/query".to_string(), ethereum_call.encode(), None)
     }
 
     fn event_exists_in_system(event_id: &EthEventId) -> bool {


### PR DESCRIPTION
## Proposed changes

This change hardens `avn-service` by extending its interface so that all `sign` and `send` operations must include a proof before execution. The proof is a signature of the request data (using the schema defined by the runtime) and is attached as a header to the POST request.

This ensures that only properly authorized requests can trigger signing or sending actions.

References:
- SYS-4664
- M-06

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

