### PR TITLE
chore: Makes Avn pallet distinct from AVN type for mocks and tests

### DIFF
--- a/pallets/authors-manager/src/mock.rs
+++ b/pallets/authors-manager/src/mock.rs
@@ -94,7 +94,7 @@ frame_support::construct_runtime!(
         AuthorsManager: authors_manager::{Pallet, Call, Storage, Event<T>, Config<T>},
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-        AVN: pallet_avn::{Pallet, Storage, Event},
+        Avn: pallet_avn::{Pallet, Storage, Event},
         EthBridge: pallet_eth_bridge::{Pallet, Call, Storage, Event<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
     }
@@ -128,7 +128,7 @@ parameter_types! {
 
 impl Config for TestRuntime {
     type RuntimeEvent = RuntimeEvent;
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type ValidatorRegistrationNotifier = Self;
     type WeightInfo = default_weights::SubstrateWeight<TestRuntime>;
     type BridgeInterface = EthBridge;
@@ -191,13 +191,13 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type MinEthBlockConfirmation = ConstU64<20>;
     type RuntimeCall = RuntimeCall;
     type WeightInfo = ();
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
     type ProcessedEventsHandler = ();
     type EthereumEventsMigration = ();
-    type Quorum = AVN;
+    type Quorum = Avn;
 }
 
 impl BridgeInterfaceNotification for TestRuntime {
@@ -219,7 +219,7 @@ impl session::Config for TestRuntime {
     type SessionManager = AuthorsManager;
     type Keys = UintAuthorityId;
     type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
-    type SessionHandler = (AVN,);
+    type SessionHandler = (Avn,);
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = AccountId;
     type ValidatorIdOf = ConvertInto;

--- a/pallets/authors-manager/src/tests.rs
+++ b/pallets/authors-manager/src/tests.rs
@@ -489,7 +489,7 @@ mod bridge_interface_notification {
             let mut ext = ExtBuilder::build_default().with_authors().as_externality();
             ext.execute_with(|| {
                 let context = MockData::setup_valid();
-                let (ingress_counter, tx_id) = setup_test_action(&context);
+                let (_ingress_counter, tx_id) = setup_test_action(&context);
 
                 advance_session();
                 advance_session();
@@ -513,7 +513,7 @@ mod bridge_interface_notification {
             let mut ext = ExtBuilder::build_default().with_authors().as_externality();
             ext.execute_with(|| {
                 let context = MockData::setup_valid();
-                let (ingress_counter, tx_id) = setup_test_action(&context);
+                let (_ingress_counter, tx_id) = setup_test_action(&context);
 
                 advance_session();
                 advance_session();

--- a/pallets/avn-offence-handler/src/mock.rs
+++ b/pallets/avn-offence-handler/src/mock.rs
@@ -20,7 +20,7 @@ frame_support::construct_runtime!(
     pub enum TestRuntime {
         System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
-        AVN: pallet_avn::{Pallet, Storage, Event},
+        Avn: pallet_avn::{Pallet, Storage, Event},
         AvnOffenceHandler: avn_offence_handler::{Pallet, Call, Storage, Event<T>},
     }
 );
@@ -71,7 +71,7 @@ impl session::Config for TestRuntime {
     type SessionManager = TestSessionManager;
     type Keys = UintAuthorityId;
     type ShouldEndSession = session::PeriodicSessions<Period, Offset>;
-    type SessionHandler = (AVN,);
+    type SessionHandler = (Avn,);
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = u64;
     type ValidatorIdOf = ConvertInto;

--- a/pallets/avn-proxy/src/tests/mock.rs
+++ b/pallets/avn-proxy/src/tests/mock.rs
@@ -65,7 +65,7 @@ frame_support::construct_runtime!(
         Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
         NftManager: pallet_nft_manager::{Pallet, Call, Storage, Event<T>},
         AvnProxy: avn_proxy::{Pallet, Call, Storage, Event<T>},
-        AVN: pallet_avn::{Pallet, Storage, Event, Config<T>},
+        Avn: pallet_avn::{Pallet, Storage, Event, Config<T>},
         TokenManager: pallet_token_manager::{Pallet, Call, Storage, Event<T>},
         Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>},
         EthBridge: pallet_eth_bridge::{Pallet, Call, Storage, Event<T>},
@@ -202,13 +202,13 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type MinEthBlockConfirmation = ConstU64<20>;
     type RuntimeCall = RuntimeCall;
     type WeightInfo = ();
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
     type ProcessedEventsHandler = ();
     type EthereumEventsMigration = ();
-    type Quorum = AVN;
+    type Quorum = Avn;
 }
 
 impl pallet_timestamp::Config for TestRuntime {
@@ -227,7 +227,7 @@ impl session::Config for TestRuntime {
     type SessionManager = ();
     type Keys = UintAuthorityId;
     type ShouldEndSession = session::PeriodicSessions<Period, Offset>;
-    type SessionHandler = (AVN,);
+    type SessionHandler = (Avn,);
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = AccountId;
     type ValidatorIdOf = ConvertInto;

--- a/pallets/ethereum-events/src/mock.rs
+++ b/pallets/ethereum-events/src/mock.rs
@@ -52,7 +52,7 @@ frame_support::construct_runtime!(
         System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-        AVN: pallet_avn::{Pallet, Storage, Event, Config<T>},
+        Avn: pallet_avn::{Pallet, Storage, Event, Config<T>},
         AvnProxy: pallet_avn_proxy::{Pallet, Call, Storage, Event<T>},
         EthereumEvents: pallet_ethereum_events::{Pallet, Call, Storage, Event<T>, Config<T>},
         Historical: pallet_session::historical::{Pallet, Storage},
@@ -188,7 +188,7 @@ impl session::Config for TestRuntime {
         pallet_session::historical::NoteHistoricalRoot<TestRuntime, TestSessionManager>;
     type Keys = UintAuthorityId;
     type ShouldEndSession = session::PeriodicSessions<Period, Offset>;
-    type SessionHandler = (AVN,);
+    type SessionHandler = (Avn,);
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = AccountId;
     type ValidatorIdOf = ConvertInto;
@@ -380,18 +380,18 @@ impl EthereumEvents {
 
     pub fn validators() -> WeakBoundedVec<Validator<AuthorityId, AccountId>, MaximumValidatorsBound>
     {
-        return AVN::active_validators()
+        return Avn::active_validators()
     }
 
     pub fn is_primary_validator_for_block(
         block_number: BlockNumberFor<TestRuntime>,
         validator: &AccountId,
     ) -> Result<bool, avn_error<TestRuntime>> {
-        return AVN::is_primary_for_block(block_number, validator)
+        return Avn::is_primary_for_block(block_number, validator)
     }
 
     pub fn get_validator_for_current_node() -> Option<Validator<AuthorityId, AccountId>> {
-        return AVN::get_validator_for_current_node()
+        return Avn::get_validator_for_current_node()
     }
 
     pub fn event_emitted(event: &RuntimeEvent) -> bool {
@@ -571,7 +571,7 @@ pub fn inject_ethereum_node_response(
         response_type: EthQueryResponseType::TransactionReceipt,
     };
     let sender = [0; 32];
-    let contract_address = AVN::get_bridge_contract_address();
+    let contract_address = Avn::get_bridge_contract_address();
     let ethereum_call = EthTransaction::new(sender, contract_address, calldata.encode());
 
     state.expect_request(PendingRequest {
@@ -601,7 +601,7 @@ pub fn simulate_http_response(
         Some(test_json(
             &unchecked_event.transaction_hash,
             &unchecked_event.signature,
-            &AVN::get_bridge_contract_address(),
+            &Avn::get_bridge_contract_address(),
             log_data,
             event_topics,
             status,

--- a/pallets/nft-manager/src/tests/mock.rs
+++ b/pallets/nft-manager/src/tests/mock.rs
@@ -43,7 +43,7 @@ frame_support::construct_runtime!(
     pub enum TestRuntime
     {
         System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
-        AVN: pallet_avn::{Pallet, Storage, Event},
+        Avn: pallet_avn::{Pallet, Storage, Event},
         NftManager: nft_manager::{Pallet, Call, Storage, Event<T>},
     }
 );

--- a/pallets/parachain-staking/src/tests/mock.rs
+++ b/pallets/parachain-staking/src/tests/mock.rs
@@ -64,7 +64,7 @@ construct_runtime!(
         ParachainStaking: pallet_parachain_staking::{Pallet, Call, Storage, Config<T>, Event<T>},
         Authorship: pallet_authorship::{Pallet, Storage},
         TransactionPayment: pallet_transaction_payment::{Pallet, Storage, Event<T>, Config<T>},
-        AVN: pallet_avn::{Pallet, Storage, Event},
+        Avn: pallet_avn::{Pallet, Storage, Event},
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
         AvnProxy: avn_proxy::{Pallet, Call, Storage, Event<T>},
         Historical: pallet_session::historical::{Pallet, Storage},
@@ -218,7 +218,7 @@ impl Config for Test {
     type CollatorPayoutDustHandler = TestCollatorPayoutDustHandler;
     type WeightInfo = ();
     type MaxCandidates = MaxCandidates;
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type BridgeInterface = EthBridge;
     type GrowthEnabled = TestGrowthEnabled;
 }
@@ -309,7 +309,7 @@ impl session::Config for Test {
     type SessionManager = ParachainStaking;
     type Keys = UintAuthorityId;
     type ShouldEndSession = ParachainStaking;
-    type SessionHandler = (AVN,);
+    type SessionHandler = (Avn,);
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = AccountId;
     type ValidatorIdOf = ConvertInto;
@@ -336,13 +336,13 @@ impl pallet_eth_bridge::Config for Test {
     type RuntimeCall = RuntimeCall;
     type MinEthBlockConfirmation = ConstU64<20>;
     type WeightInfo = ();
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
     type ProcessedEventsHandler = ();
     type EthereumEventsMigration = ();
-    type Quorum = AVN;
+    type Quorum = Avn;
 }
 
 impl pallet_timestamp::Config for Test {

--- a/pallets/summary/src/tests/mock.rs
+++ b/pallets/summary/src/tests/mock.rs
@@ -336,7 +336,7 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
-        AVN: pallet_avn::{Pallet, Storage, Event},
+        Avn: pallet_avn::{Pallet, Storage, Event},
         Summary: summary::{Pallet, Call, Storage, Event<T>, Config<T>},
         Historical: pallet_session::historical::{Pallet, Storage},
         EthBridge: pallet_eth_bridge::{Pallet, Call, Storage, Event<T>},
@@ -432,13 +432,13 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type RuntimeCall = RuntimeCall;
     type MinEthBlockConfirmation = ConstU64<20>;
     type WeightInfo = ();
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = OffenceHandler;
     type ProcessedEventsChecker = ();
     type ProcessedEventsHandler = ();
     type EthereumEventsMigration = ();
-    type Quorum = AVN;
+    type Quorum = Avn;
 }
 
 impl pallet_timestamp::Config for TestRuntime {
@@ -564,7 +564,7 @@ impl session::Config for TestRuntime {
         pallet_session::historical::NoteHistoricalRoot<TestRuntime, TestSessionManager>;
     type Keys = UintAuthorityId;
     type ShouldEndSession = session::PeriodicSessions<Period, Offset>;
-    type SessionHandler = (AVN,);
+    type SessionHandler = (Avn,);
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = u64;
     type ValidatorIdOf = ConvertInto;

--- a/pallets/summary/src/tests/tests.rs
+++ b/pallets/summary/src/tests/tests.rs
@@ -377,7 +377,7 @@ mod process_summary_if_required {
                 setup_blocks(&context);
                 setup_total_ingresses(&context);
                 let root_lock_name = Summary::create_root_lock_name(context.last_block_in_range);
-                let mut lock = AVN::get_ocw_locker(&root_lock_name);
+                let mut lock = Avn::get_ocw_locker(&root_lock_name);
                 if let Ok(_guard) = lock.try_lock() {
                     assert!(pool_state.read().transactions.is_empty());
 

--- a/pallets/summary/src/tests/tests_challenge.rs
+++ b/pallets/summary/src/tests/tests_challenge.rs
@@ -189,7 +189,7 @@ mod challenge_slot_if_required {
                 // We add 2 to make sure context.slot_validator is the primary for this block number
                 let block_after_grace_period = context.block_after_grace_period + 2;
 
-                assert!(AVN::is_primary_for_block(
+                assert!(Avn::is_primary_for_block(
                     block_after_grace_period,
                     &context.slot_validator.account_id
                 )
@@ -360,7 +360,7 @@ mod challenge_slot_if_required {
 
         fn get_primary_for_block(block_number: BlockNumber) -> MockValidator {
             let primary_validator_account_id =
-                AVN::calculate_primary_validator_for_block(block_number).unwrap();
+                Avn::calculate_primary_validator_for_block(block_number).unwrap();
             return get_validator(primary_validator_account_id)
         }
 

--- a/pallets/summary/src/tests/tests_vote.rs
+++ b/pallets/summary/src/tests/tests_vote.rs
@@ -754,7 +754,7 @@ mod cast_votes_if_required {
                 // TODO [TYPE: test][PRI: medium][JIRA: 321]: mock of set_lock_with_expiry returns
                 // error
                 let lock_name = vote::create_vote_lock_name::<TestRuntime, ()>(&context.root_id);
-                let mut lock = AVN::get_ocw_locker(&lock_name);
+                let mut lock = Avn::get_ocw_locker(&lock_name);
 
                 // Protect against sending more than once. When guard is out of scope the lock will
                 // be released.
@@ -897,7 +897,7 @@ mod end_voting_period {
                 Summary::set_previous_summary_slot(5);
 
                 let primary_validator_id =
-                    AVN::calculate_primary_validator_for_block(context.current_block_number)
+                    Avn::calculate_primary_validator_for_block(context.current_block_number)
                         .expect("Should be able to calculate primary validator.");
                 let primary_validator = get_validator(primary_validator_id);
 
@@ -1092,7 +1092,7 @@ mod end_voting_period {
                     .for_offchain_worker()
                     .as_externality_with_state();
                 ext.execute_with(|| {
-                    let active_validators = AVN::validators();
+                    let active_validators = Avn::validators();
                     assert_eq!(active_validators.len(), TEST_VALIDATOR_COUNT as usize);
 
                     let context = setup_context();
@@ -1170,7 +1170,7 @@ mod end_voting_period {
                     .for_offchain_worker()
                     .as_externality_with_state();
                 ext.execute_with(|| {
-                    let active_validators = AVN::validators();
+                    let active_validators = Avn::validators();
                     assert_eq!(active_validators.len(), TEST_VALIDATOR_COUNT as usize);
 
                     let context = setup_context();
@@ -1209,7 +1209,7 @@ mod end_voting_period {
                     .for_offchain_worker()
                     .as_externality_with_state();
                 ext.execute_with(|| {
-                    let active_validators = AVN::validators();
+                    let active_validators = Avn::validators();
                     assert_eq!(active_validators.len(), TEST_VALIDATOR_COUNT as usize);
 
                     let context = setup_context();
@@ -1291,7 +1291,7 @@ mod end_voting_period {
                     .for_offchain_worker()
                     .as_externality_with_state();
                 ext.execute_with(|| {
-                    let active_validators = AVN::validators();
+                    let active_validators = Avn::validators();
                     assert_eq!(active_validators.len(), TEST_VALIDATOR_COUNT as usize);
 
                     let context = setup_context();
@@ -1313,7 +1313,7 @@ mod end_voting_period {
                     .for_offchain_worker()
                     .as_externality_with_state();
                 ext.execute_with(|| {
-                    let active_validators = AVN::validators();
+                    let active_validators = Avn::validators();
                     assert_eq!(active_validators.len(), TEST_VALIDATOR_COUNT as usize);
 
                     let context = setup_context();
@@ -1336,7 +1336,7 @@ mod end_voting_period {
                     .for_offchain_worker()
                     .as_externality_with_state();
                 ext.execute_with(|| {
-                    let active_validators = AVN::validators();
+                    let active_validators = Avn::validators();
                     assert_eq!(active_validators.len(), TEST_VALIDATOR_COUNT as usize);
 
                     let context = setup_context();
@@ -1364,7 +1364,7 @@ mod end_voting_period {
                     .for_offchain_worker()
                     .as_externality_with_state();
                 ext.execute_with(|| {
-                    let active_validators = AVN::validators();
+                    let active_validators = Avn::validators();
                     assert_eq!(active_validators.len(), TEST_VALIDATOR_COUNT as usize);
 
                     let context = setup_context();

--- a/pallets/token-manager/src/mock.rs
+++ b/pallets/token-manager/src/mock.rs
@@ -72,7 +72,7 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-        AVN: pallet_avn::{Pallet, Storage, Event},
+        Avn: pallet_avn::{Pallet, Storage, Event},
         TokenManager: token_manager::{Pallet, Call, Storage, Event<T>, Config<T>},
         TransactionPayment: pallet_transaction_payment::{Pallet, Storage, Event<T>, Config<T>},
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
@@ -218,7 +218,7 @@ impl session::Config for TestRuntime {
     type SessionManager = ParachainStaking;
     type Keys = UintAuthorityId;
     type ShouldEndSession = ParachainStaking;
-    type SessionHandler = (AVN,);
+    type SessionHandler = (Avn,);
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = AccountId;
     type ValidatorIdOf = ConvertInto;
@@ -261,7 +261,7 @@ impl parachain_staking::Config for TestRuntime {
     type ProcessedEventsChecker = ();
     type WeightInfo = ();
     type MaxCandidates = MaxCandidates;
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type BridgeInterface = EthBridge;
     type GrowthEnabled = GrowthEnabled;
 }
@@ -278,13 +278,13 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type RuntimeCall = RuntimeCall;
     type MinEthBlockConfirmation = ConstU64<20>;
     type WeightInfo = ();
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
     type ProcessedEventsHandler = ();
     type EthereumEventsMigration = ();
-    type Quorum = AVN;
+    type Quorum = Avn;
 }
 
 impl pallet_timestamp::Config for TestRuntime {

--- a/pallets/validators-manager/src/tests/mock.rs
+++ b/pallets/validators-manager/src/tests/mock.rs
@@ -20,9 +20,7 @@ use sp_avn_common::{
 use sp_core::{
     ecdsa::Public,
     offchain::{
-        testing::{
-            OffchainState, PendingRequest, PoolState, TestOffchainExt, TestTransactionPoolExt,
-        },
+        testing::{OffchainState, PoolState, TestOffchainExt, TestTransactionPoolExt},
         OffchainDbExt, OffchainWorkerExt, TransactionPoolExt,
     },
     sr25519, ByteArray, ConstU64, Pair, H256,
@@ -72,7 +70,6 @@ pub type Signature = sr25519::Signature;
 /// An identifier for an account on this system.
 pub type AccountId = <Signature as Verify>::Signer;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
 // TODO: Refactor this struct to be reused in all tests
 #[derive(Clone)]
@@ -107,7 +104,7 @@ frame_support::construct_runtime!(
         ValidatorManager: validators_manager::{Pallet, Call, Storage, Event<T>, Config<T>},
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-        AVN: pallet_avn::{Pallet, Storage, Event},
+        Avn: pallet_avn::{Pallet, Storage, Event},
         ParachainStaking: parachain_staking::{Pallet, Call, Storage, Config<T>, Event<T>},
         EthBridge: pallet_eth_bridge::{Pallet, Call, Storage, Event<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
@@ -144,7 +141,7 @@ impl Config for TestRuntime {
     type RuntimeEvent = RuntimeEvent;
     type ProcessedEventsChecker = Self;
     type VotingPeriod = VotingPeriod;
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type ValidatorRegistrationNotifier = Self;
     type WeightInfo = ();
     type BridgeInterface = EthBridge;
@@ -208,13 +205,13 @@ impl pallet_eth_bridge::Config for TestRuntime {
     type MinEthBlockConfirmation = ConstU64<20>;
     type RuntimeCall = RuntimeCall;
     type WeightInfo = ();
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type BridgeInterfaceNotification = Self;
     type ReportCorroborationOffence = ();
     type ProcessedEventsChecker = ();
     type ProcessedEventsHandler = ();
     type EthereumEventsMigration = ();
-    type Quorum = AVN;
+    type Quorum = Avn;
 }
 
 impl BridgeInterfaceNotification for TestRuntime {
@@ -236,7 +233,7 @@ impl session::Config for TestRuntime {
     type SessionManager = ParachainStaking;
     type Keys = UintAuthorityId;
     type ShouldEndSession = ParachainStaking;
-    type SessionHandler = (AVN,);
+    type SessionHandler = (Avn,);
     type RuntimeEvent = RuntimeEvent;
     type ValidatorId = AccountId;
     type ValidatorIdOf = ConvertInto;
@@ -284,13 +281,10 @@ impl parachain_staking::Config for TestRuntime {
     type ProcessedEventsChecker = ();
     type WeightInfo = ();
     type MaxCandidates = MaxCandidates;
-    type AccountToBytesConvert = AVN;
+    type AccountToBytesConvert = Avn;
     type BridgeInterface = EthBridge;
     type GrowthEnabled = GrowthEnabled;
 }
-
-/// An extrinsic type used for tests.
-type IdentificationTuple = (AccountId, AccountId);
 
 pub const INITIAL_TRANSACTION_ID: EthereumTransactionId = 0;
 


### PR DESCRIPTION
## Proposed changes

This removes related warnings and future proof the tests for future versions of Rust.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
