### PR TITLE
fix: Tests dependencies to remove bandersnatch dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7577,7 +7577,6 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.6.0)",
- "substrate-test-utils",
 ]
 
 [[package]]
@@ -7657,7 +7656,6 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.6.0)",
- "substrate-test-utils",
 ]
 
 [[package]]
@@ -7679,7 +7677,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.6.0)",
- "substrate-test-utils",
 ]
 
 [[package]]
@@ -8046,7 +8043,6 @@ dependencies = [
  "sp-staking",
  "sp-state-machine",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.6.0)",
- "substrate-test-utils",
 ]
 
 [[package]]
@@ -8235,7 +8231,6 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.6.0)",
- "substrate-test-utils",
 ]
 
 [[package]]
@@ -8669,7 +8664,6 @@ dependencies = [
  "sp-staking",
  "sp-state-machine",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.6.0)",
- "substrate-test-utils",
 ]
 
 [[package]]
@@ -8740,7 +8734,6 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.6.0)",
- "substrate-test-utils",
 ]
 
 [[package]]
@@ -8855,7 +8848,6 @@ dependencies = [
  "sp-staking",
  "sp-state-machine",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.6.0)",
- "substrate-test-utils",
 ]
 
 [[package]]

--- a/pallets/authors-manager/src/tests.rs
+++ b/pallets/authors-manager/src/tests.rs
@@ -6,8 +6,8 @@ use crate::{mock::*, AVN, *};
 use frame_support::{assert_noop, assert_ok, traits::Currency};
 use frame_system::RawOrigin;
 use hex_literal::hex;
+use sp_avn_common::assert_eq_uvec;
 use sp_runtime::{testing::UintAuthorityId, traits::BadOrigin};
-use substrate_test_utils::assert_eq_uvec;
 
 fn register_author(author_id: &AccountId, author_eth_public_key: &ecdsa::Public) -> DispatchResult {
     return AuthorsManager::add_author(RawOrigin::Root.into(), *author_id, *author_eth_public_key)

--- a/pallets/authors-manager/src/tests.rs
+++ b/pallets/authors-manager/src/tests.rs
@@ -1,4 +1,4 @@
-//Copyright 2024 Aventus Network Services (UK) Ltd.
+//Copyright 2025 Aventus Network Services (UK) Ltd.
 
 #![cfg(test)]
 

--- a/pallets/avn-proxy/Cargo.toml
+++ b/pallets/avn-proxy/Cargo.toml
@@ -35,7 +35,6 @@ libsecp256k1 = { version = "0.7.0", default-features = false, features =["hmac",
 hex = "0.4"
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
-substrate-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", features=["insecure_zero_ed"] }
 pallet-scheduler = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }

--- a/pallets/avn-transaction-payment/Cargo.toml
+++ b/pallets/avn-transaction-payment/Cargo.toml
@@ -33,7 +33,6 @@ frame-benchmarking = { default-features = false, git = "https://github.com/parit
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
-substrate-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", features=["insecure_zero_ed"] }
 sp-avn-common = { features=["test-utils"], path = "../../primitives/avn-common" }
 

--- a/pallets/avn/Cargo.toml
+++ b/pallets/avn/Cargo.toml
@@ -39,7 +39,6 @@ frame-benchmarking = { default-features = false, git = "https://github.com/parit
 hex-literal = { version = "0.4.1", default-features = false }
 parking_lot = { version = "0.12.0" }
 pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
-substrate-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", features=["insecure_zero_ed"] }
 sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 sp-avn-common = { features=["test-utils"], path = "../../primitives/avn-common" }

--- a/pallets/ethereum-events/Cargo.toml
+++ b/pallets/ethereum-events/Cargo.toml
@@ -42,7 +42,6 @@ frame-benchmarking = { default-features = false, git = "https://github.com/parit
 
 [dev-dependencies]
 pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
-substrate-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", features=["insecure_zero_ed"] }
 sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 pallet-avn-proxy = { default-features = false, path = "../avn-proxy" }

--- a/pallets/nft-manager/Cargo.toml
+++ b/pallets/nft-manager/Cargo.toml
@@ -33,7 +33,6 @@ frame-benchmarking = { default-features = false, git = "https://github.com/parit
 
 # serde = { version = "1.0.195", default-features = false, optional = true }
 [dev-dependencies]
-substrate-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 parking_lot = { version = "0.12.0" }
 sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 sp-avn-common = { features=["test-utils"], path = "../../primitives/avn-common" }

--- a/pallets/summary/Cargo.toml
+++ b/pallets/summary/Cargo.toml
@@ -38,7 +38,6 @@ pallet-session = { default-features = false, features = [
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", optional = true }
 
 [dev-dependencies]
-substrate-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 node-primitives = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 parking_lot = { version = "0.12.0" }
 pallet-session = { features = [

--- a/pallets/token-manager/Cargo.toml
+++ b/pallets/token-manager/Cargo.toml
@@ -34,7 +34,6 @@ frame-system = { default-features = false, git = "https://github.com/paritytech/
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", optional = true }
 
 [dev-dependencies]
-substrate-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", features=["insecure_zero_ed"] }
 pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }

--- a/pallets/validators-manager/Cargo.toml
+++ b/pallets/validators-manager/Cargo.toml
@@ -49,7 +49,6 @@ frame-benchmarking = { default-features = false, git = "https://github.com/parit
 [dev-dependencies]
 frame-election-provider-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
-substrate-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 parking_lot = { version = "0.12.0" }
 pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0",features=["insecure_zero_ed"] }
 sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -8,10 +8,9 @@ use frame_support::{
 };
 use hex_literal::hex;
 use pallet_parachain_staking::Error as ParachainStakingError;
+use sp_avn_common::assert_eq_uvec;
 use sp_io::crypto::{secp256k1_ecdsa_recover, secp256k1_ecdsa_recover_compressed};
 use sp_runtime::{testing::UintAuthorityId, traits::BadOrigin};
-use substrate_test_utils::assert_eq_uvec;
-// use frame_system::*;
 
 fn register_validator(
     collator_id: &AccountId,

--- a/pallets/validators-manager/src/tests/tests.rs
+++ b/pallets/validators-manager/src/tests/tests.rs
@@ -1,4 +1,4 @@
-//Copyright 2022 Aventus Network Services (UK) Ltd.
+//Copyright 2025 Aventus Network Services (UK) Ltd.
 
 #![cfg(test)]
 

--- a/primitives/avn-common/src/tests/helpers.rs
+++ b/primitives/avn-common/src/tests/helpers.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Aventus Network Services (UK) Ltd.
+// Copyright 2025 Aventus Network Services (UK) Ltd.
 
 pub mod ethereum_converters {
     use sp_std::vec::Vec;

--- a/primitives/avn-common/src/tests/helpers.rs
+++ b/primitives/avn-common/src/tests/helpers.rs
@@ -15,3 +15,29 @@ pub mod ethereum_converters {
         return vec![n; 32]
     }
 }
+
+pub mod utilities {
+    // copied from substrate-test-utils to avoid errors in dependencies.
+    #[macro_export]
+    macro_rules! assert_eq_uvec {
+        ($x:expr, $y:expr $(,)?) => {{
+            ($x).iter().for_each(|e| {
+                if !($y).contains(e) {
+                    panic!(
+                        "assert_eq_uvec! failed: left has an element not in right.\nleft:  {:?}\nright: {:?}\nmissing: {:?}",
+                        $x, $y, e
+                    );
+                }
+            });
+
+            ($y).iter().for_each(|e| {
+                if !($x).contains(e) {
+                    panic!(
+                        "assert_eq_uvec! failed: right has an element not in left.\nleft:  {:?}\nright: {:?}\nmissing: {:?}",
+                        $x, $y, e
+                    );
+                }
+            });
+        }};
+    }
+}


### PR DESCRIPTION
## Proposed changes

This avoid compilation errors due to broken dependencies of bandersnatch_vrfs in older versions of polkadot-sdk.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [ ] Release <!---Mark this option if a new release/version will born from this PR-->
  - [ ] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] You describe the purpose of the PR, e.g.:
  - What does it do?
  - Highlight what important points reviewers should know about;
  - Indicates if there is something left for follow-up PRs.
- [ ] Documentation updated
- [ ] Business logic tested successfully
- [ ] Verify First, Write Last: In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the function's computation.

## Further comments

<!---If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc-->
